### PR TITLE
Add new translations (pt, fr, es) and fix existing ones (en, de)

### DIFF
--- a/matrix-meetings-bot/README.md
+++ b/matrix-meetings-bot/README.md
@@ -20,7 +20,7 @@ There are two ways to setup the NeoDateFix widget using the bot:
 In a private chat-room you can use the following commands:
 
 - `!meeting help`: shows all available commands.
-- `!meeting lang <en|de>` Change bot's language in this room
+- `!meeting lang <pt|en|fr|es|de>` Change bot's language in this room
 - `!meeting detail` Show the manual about NeoDateFix widget setup in the room
 - `!meeting setup` Adds a NeoDateFix widget to the room
 - `!meeting status` Check the ability to add the NeoDateFix widget

--- a/matrix-meetings-bot/i18next-parser.config.js
+++ b/matrix-meetings-bot/i18next-parser.config.js
@@ -15,7 +15,7 @@
  */
 
 module.exports = {
-  locales: ['en', 'de'],
+  locales: ['pt', 'en', 'fr', 'es', 'de'],
   output: 'src/static/locales/$LOCALE/$NAMESPACE.json',
   sort: true,
   resetDefaultValueLocale: 'en',

--- a/matrix-meetings-bot/setupTests.ts
+++ b/matrix-meetings-bot/setupTests.ts
@@ -21,13 +21,13 @@ import 'reflect-metadata';
 import { registerDateRangeFormatter } from './src/dateRangeFormatter';
 
 // @ts-ignore Ignore error. TypeScript complains, even if 'resolveJsonModule' is enabled.
-import translationDe from './src/static/locales/pt/translation.json';
+import translationPt from './src/static/locales/pt/translation.json';
 // @ts-ignore Ignore error. TypeScript complains, even if 'resolveJsonModule' is enabled.
 import translationEn from './src/static/locales/en/translation.json';
 // @ts-ignore Ignore error. TypeScript complains, even if 'resolveJsonModule' is enabled.
-import translationEn from './src/static/locales/fr/translation.json';
+import translationFr from './src/static/locales/fr/translation.json';
 // @ts-ignore Ignore error. TypeScript complains, even if 'resolveJsonModule' is enabled.
-import translationEn from './src/static/locales/es/translation.json';
+import translationEs from './src/static/locales/es/translation.json';
 // @ts-ignore Ignore error. TypeScript complains, even if 'resolveJsonModule' is enabled.
 import translationDe from './src/static/locales/de/translation.json';
 
@@ -41,7 +41,10 @@ i18next.use(i18nextBackend).init({
     escapeValue: false,
   },
   resources: {
+    pt: { translation: translationPt },
     en: { translation: translationEn },
+    fr: { translation: translationFr },
+    es: { translation: translationEs },
     de: { translation: translationDe },
   },
 });

--- a/matrix-meetings-bot/setupTests.ts
+++ b/matrix-meetings-bot/setupTests.ts
@@ -21,16 +21,22 @@ import 'reflect-metadata';
 import { registerDateRangeFormatter } from './src/dateRangeFormatter';
 
 // @ts-ignore Ignore error. TypeScript complains, even if 'resolveJsonModule' is enabled.
-import translationDe from './src/static/locales/de/translation.json';
+import translationDe from './src/static/locales/pt/translation.json';
 // @ts-ignore Ignore error. TypeScript complains, even if 'resolveJsonModule' is enabled.
 import translationEn from './src/static/locales/en/translation.json';
+// @ts-ignore Ignore error. TypeScript complains, even if 'resolveJsonModule' is enabled.
+import translationEn from './src/static/locales/fr/translation.json';
+// @ts-ignore Ignore error. TypeScript complains, even if 'resolveJsonModule' is enabled.
+import translationEn from './src/static/locales/es/translation.json';
+// @ts-ignore Ignore error. TypeScript complains, even if 'resolveJsonModule' is enabled.
+import translationDe from './src/static/locales/de/translation.json';
 
 // Use a different configuration for i18next during tests
 i18next.use(i18nextBackend).init({
   debug: false,
   saveMissing: true,
   fallbackLng: 'en',
-  preload: ['en', 'de'],
+  preload: ['pt', 'en', 'fr', 'es', 'de'],
   interpolation: {
     escapeValue: false,
   },

--- a/matrix-meetings-bot/src/app.module.ts
+++ b/matrix-meetings-bot/src/app.module.ts
@@ -196,7 +196,13 @@ const appRuntimeContextFactory: FactoryProvider<Promise<AppRuntimeContext>> = {
     } catch (_err) {
       displayName = localpart;
     }
-    return new AppRuntimeContext(userId, displayName, localpart, ['pt', 'en', 'fr', 'es', 'de']);
+    return new AppRuntimeContext(userId, displayName, localpart, [
+      'pt',
+      'en',
+      'fr',
+      'es',
+      'de',
+    ]);
   },
   inject: [MatrixClient],
 };

--- a/matrix-meetings-bot/src/app.module.ts
+++ b/matrix-meetings-bot/src/app.module.ts
@@ -196,7 +196,7 @@ const appRuntimeContextFactory: FactoryProvider<Promise<AppRuntimeContext>> = {
     } catch (_err) {
       displayName = localpart;
     }
-    return new AppRuntimeContext(userId, displayName, localpart, ['en', 'de']);
+    return new AppRuntimeContext(userId, displayName, localpart, ['pt', 'en', 'fr', 'es', 'de']);
   },
   inject: [MatrixClient],
 };

--- a/matrix-meetings-bot/src/static/locales/de/translation.json
+++ b/matrix-meetings-bot/src/static/locales/de/translation.json
@@ -24,7 +24,7 @@
   "commandHelp": [
     "<p>Verfügbare Befehle:</p>",
     "<ul>",
-    "<li><code>!meeting lang &lt;en|de&gt;</code> (Die Sprache des {{botName}} in diesem Raum ändern.)</li>",
+    "<li><code>!meeting lang &lt;pt|en|fr|es|de&gt;</code> (Die Sprache des {{botName}} in diesem Raum ändern.)</li>",
     "<li><code>!meeting setup</code> (Fügt den Kalender zum Raum hinzu.)</li>",
     "<li><code>!meeting status</code> (Überprüft die Fähigkeit, den Kalender hinzufügen zu können.)</li>",
     "</ul>"
@@ -137,8 +137,11 @@
     "introLanguage": [
       "Information zur Spracheinstellung: Um eine Kommunikation in deiner gewohnten Sprache zu ermöglichen, kannst du folgende Befehle benutzen:",
       "<ul>",
-      "<li>Sprache auf Deutsch umstellen: <code>!meeting lang de</code></li>",
-      "<li>Change language to English: <code>!meeting lang en</code></li>",
+      "<li>Sprache auf Portugiesisch ändern: <code>!meeting lang pt</code></li>",
+      "<li>Sprache auf Englisch ändern: <code>!meeting lang en</code></li>",
+      "<li>Sprache auf Französisch ändern: <code>!meeting lang fr</code></li>",
+      "<li>Sprache auf Spanisch ändern: <code>!meeting lang es</code></li>",
+      "<li>Sprache auf Deutsch ändern: <code>!meeting lang de</code></li>",
       "</ul>"
     ],
     "languageWasChanged": "Die Sprache wurde auf <b>{{locale}}</b> geändert.",

--- a/matrix-meetings-bot/src/static/locales/en/translation.json
+++ b/matrix-meetings-bot/src/static/locales/en/translation.json
@@ -24,7 +24,7 @@
   "commandHelp": [
     "<p>Available commands:</p>",
     "<ul>",
-    "<li><code>!meeting lang &lt;en|de&gt;</code> (Change the language of the bot in this room.)</li>",
+    "<li><code>!meeting lang &lt;pt|en|fr|es|de&gt;</code> (Change the language of the bot in this room.)</li>",
     "<li><code>!meeting setup</code> (Adds the calendar to the room.)</li>",
     "<li><code>!meeting status</code> (Checks the ability to add the calendar.)</li>",
     "</ul>"
@@ -89,9 +89,9 @@
       "daily_one": "Every day$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
       "daily_other": "Every {{count}} days$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
       "monthly_bymonthday_one": "Every month on the $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-      "monthly_bymonthday_other": "Every {{count}} months on the $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_bymonthday_other": "Every {{count}} month on the $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
       "monthly_byweekday_one": "Every month on the {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-      "monthly_byweekday_other": "Every {{count}} months on the {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_byweekday_other": "Every {{count}} month on the {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
       "monthly_simple_one": "Every month$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
       "monthly_simple_other": "Every {{count}} months$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
       "ordinal_ordinal_one": "{{count}}st",
@@ -105,13 +105,13 @@
       "weekly_all_one": "Every week$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
       "weekly_all_other": "Every {{count}} weeks$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
       "weekly_some_one": "Every week on {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-      "weekly_some_other": "Every {{count}} weeks on {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_some_other": "Every {{count}} week on {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
       "weekly_weekdays_one": "Every weekday$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-      "weekly_weekdays_other": "Every {{count}} weeks on weekdays$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_weekdays_other": "Every {{count}} week on weekdays$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
       "yearly_bymonthday_one": "Every {{monthLabel}} on the $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-      "yearly_bymonthday_other": "Every {{count}} years on the $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true }) of {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_bymonthday_other": "Every {{count}} year on the $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true }) of {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
       "yearly_byweekday_one": "Every {{monthLabel}} on the {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-      "yearly_byweekday_other": "Every {{count}} years on the {{ordinalLabel}} {{byweekday}} of {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_byweekday_other": "Every {{count}} year on the {{ordinalLabel}} {{byweekday}} of {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
       "yearly_simple_one": "Every year$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
       "yearly_simple_other": "Every {{count}} years$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })"
     }
@@ -140,8 +140,11 @@
     "introLanguage": [
       "Information on the language setting: To enable communication in your language, you can use the following commands:  ",
       "<ul>",
+      "<li>Change language to Portuguese: <code>!meeting lang pt</code></li>",
       "<li>Change language to English: <code>!meeting lang en</code></li>",
-      "<li>Sprache auf Deutsch umstellen: <code>!meeting lang de</code></li>",
+      "<li>Change language to French : <code>!meeting lang fr</code></li>",
+      "<li>Change language to Spanish: <code>!meeting lang es</code></li>",
+      "<li>Change language to German: <code>!meeting lang de</code></li>",
       "</ul>"
     ],
     "languageWasChanged": "The language was changed to <b>{{locale}}</b>.",

--- a/matrix-meetings-bot/src/static/locales/es/translation.json
+++ b/matrix-meetings-bot/src/static/locales/es/translation.json
@@ -1,159 +1,158 @@
 {
-    "base": {
-      "exception": {
-        "message": "Ocurrió un error \"{{errorName}}\" al procesar los eventos para la sala {{roomId}} {{roomName}}. <br> Por favor proporcione este número: [{{requestId}}] para más preguntas."
-      }
-    },
-    "bot": {
-      "private": {
-        "errorRoom": {
-          "create": {
-            "message": "Mensajes de error de NeoDateFix-Bot",
-            "topic": "Más detalles"
-          }
+  "base": {
+    "exception": {
+      "message": "Ocurrió un error \"{{errorName}}\" al procesar los eventos para la sala {{roomId}} {{roomName}}. <br> Por favor proporcione este número: [{{requestId}}] para más preguntas."
+    }
+  },
+  "bot": {
+    "private": {
+      "errorRoom": {
+        "create": {
+          "message": "Mensajes de error de NeoDateFix-Bot",
+          "topic": "Más detalles"
         }
-      }
-    },
-    "commandErrors": {
-      "badCommand": "Comando incorrecto, intente <code>{{trigger}} help</code>",
-      "badLanguageCode": "El código de idioma no es compatible",
-      "generic": "Hubo un error al procesar su comando: {{message}}",
-      "noCommandProvided": "No se proporcionó ningún comando, intente <code>{{trigger}} help</code>",
-      "noLanguageCode": "No se proporcionó un código de idioma, use uno de estos ({{availableLanguageCodes}})"
-    },
-    "commandHelp": [
-      "<p>Comandos disponibles:</p>",
-      "<ul>",
-      "<li><code>!meeting lang &lt;pt|en|fr|es|de&gt;</code> (Cambiar el idioma del bot en esta sala.)</li>",
-      "<li><code>!meeting setup</code> (Agrega el calendario a la sala.)</li>",
-      "<li><code>!meeting status</code> (Verifica la capacidad para agregar el calendario.)</li>",
-      "</ul>"
-    ],
-    "meeting": {
-      "invite": {
-        "message": "📅 {{range, daterange}}<br/>$t(meeting.invite.messageRecurrence, {\"context\": \"{{recurrenceContext}}\" })<br/>$t(meeting.invite.messageByOrganizer, {\"context\": \"{{organizerContext}}\" })$t(meeting.invite.messageDescription, {\"context\": \"{{descriptionContext}}\" })",
-        "messageByOrganizer_none": "",
-        "messageByOrganizer_present": "\nhas sido invitado a una reunión por {{organizerDisplayName}}",
-        "messageDescription_none": "",
-        "messageDescription_present": "\n<hr><i>{{description}}</i>",
-        "messageRecurrence_none": "",
-        "messageRecurrence_present": "\n🔁 Recurrencia: {{recurrence}}<br/>"
-      },
-      "room": {
-        "notification": {
-          "changed": {
-            "date": {
-              "current": "Fecha: {{range, daterange}}",
-              "previous": "(anteriormente: {{range, daterange}})"
-            },
-            "description": {
-              "current": "Descripción: {{description}}",
-              "previous": "(anteriormente: {{description}})"
-            },
-            "headLine": "CAMBIOS",
-            "occurrence": {
-              "current": "Una reunión de una serie de reuniones se movió a {{range, daterange}}",
-              "deleted": "Una reunión de una serie de reuniones en {{range, daterange}} ha sido eliminada",
-              "previous": "(anteriormente: {{value, daterange}})"
-            },
-            "repetition": {
-              "current": "Repetir reunión: {{repetitionText}}",
-              "previous": "(anteriormente: {{repetitionText}})"
-            },
-            "title": {
-              "current": "Título: {{title}}",
-              "previous": "(anteriormente: {{title}})"
-            }
-          },
-          "closed": {
-            "message": "La sala fue cerrada por el administrador"
-          },
-          "noRepetition": "Sin repetición"
-        }
-      },
-      "user": {
-        "kicked": "El usuario {{userId}} ha sido eliminado por {{sender}}"
-      }
-    },
-    "recurrenceEditor": {
-      "ordinals": {
-        "first": "primero",
-        "fourth": "cuarto",
-        "last": "último",
-        "second": "segundo",
-        "third": "tercero"
-      },
-      "ruleText": {
-        "afterMeetingCount_one": "por una vez",
-        "afterMeetingCount_other": "por {{count}} veces",
-        "daily_one": "Cada día$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "daily_other": "Cada {{count}} días$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_bymonthday_one": "Cada mes en el $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_bymonthday_other": "Cada {{count}} meses en el $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_byweekday_one": "Cada mes en el {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_byweekday_other": "Cada {{count}} meses en el {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_simple_one": "Cada mes$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_simple_other": "Cada {{count}} meses$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "ordinal_ordinal_one": "{{count}}º",
-        "ordinal_ordinal_two": "{{count}}º",
-        "ordinal_ordinal_few": "{{count}}º",
-        "ordinal_ordinal_other": "{{count}}º",
-        "recurrenceEnd_count": " $t(recurrenceEditor.ruleText.afterMeetingCount, {\"count\": {{afterMeetingCount}}, \"ordinal\": false })",
-        "recurrenceEnd_never": "",
-        "recurrenceEnd_until": " hasta {{ untilDate, datetime(year: 'numeric'; month: 'long'; day: 'numeric') }}",
-        "unknown": "Recurrencia no soportada",
-        "weekly_all_one": "Cada semana$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "weekly_all_other": "Cada {{count}} semanas$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "weekly_some_one": "Cada semana en {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "weekly_some_other": "Cada {{count}} semanas en {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "weekly_weekdays_one": "Cada día laboral$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "weekly_weekdays_other": "Cada {{count}} semanas en días laborales$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_bymonthday_one": "Cada {{monthLabel}} en el $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_bymonthday_other": "Cada {{count}} años en el $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true }) de {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_byweekday_one": "Cada {{monthLabel}} en el {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_byweekday_other": "Cada {{count}} años en el {{ordinalLabel}} {{byweekday}} de {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_simple_one": "Cada año$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_simple_other": "Cada {{count}} años$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })"
-      }
-    },
-    "welcome": {
-      "botIsAdmin": "El bot es un moderador en la sala <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>. Si ingresas el comando <code>!meeting setup</code>, el widget NeoDateFix será añadido a esa sala.",
-      "botNotAdmin": "El bot no es un moderador en la sala <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.",
-      "errors": {
-        "meetingWidgetExists": "No se puede agregar un nuevo widget porque ya existe.",
-        "notEnoughPermissions": "Desafortunadamente, no puedo agregar la función de calendario. No tengo la autorización adecuada. Por favor, dame derechos de moderador en tu sala <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>."
-      },
-      "helpWhenNotAdmin": "Desafortunadamente, no puedo agregar la función de calendario. No tengo la autorización adecuada. Por favor, dame derechos de moderador en tu sala <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.",
-      "intro": [
-        "<p>Hola {{userDisplayName}}, gracias por invitarme a la <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.</p>",
-        "<p>Estaré encantado de ayudarte a configurar tu calendario en esa sala.</p>",
-        "<p>Para que pueda agregar la función de calendario a tu sala, por favor, dame el derecho necesario para agregar widgets a la sala <a href='{{originalRoomLink}}'>{{originalRoomName}}</a> (por ejemplo, el rol de Moderador). Puedes hacerlo en mi perfil de usuario, que puedes encontrar en el menú lateral derecho a través del ícono de \"información\".</p>",
-        "<p>Si no deseas darme los permisos necesarios, puedes agregar la función de calendario a tu sala manualmente enviando el siguiente mensaje a la sala: <code>/addwidget {{widgetURL}}</code></p>",
-        "<p>Para obtener un resumen de todos los comandos, puedes enviar <code>!meeting help</code></p>"
-      ],
-      "introDone": [
-        "<p>Hola {{userDisplayName}}, gracias por invitarme a la <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.</p>",
-        "<p>Mi tarea era ayudarte a configurar el calendario.</p>",
-        "<p>El calendario ya ha sido configurado exitosamente en tu sala. Por lo tanto, ya puedes dejar este chat.</p>",
-        "<p>Para obtener un resumen de todos los comandos, puedes enviar <code>!meeting help</code></p>"
-      ],
-      "introLanguage": [
-        "Información sobre la configuración del idioma: Para habilitar la comunicación en tu idioma, puedes usar los siguientes comandos: ",
-        "<ul>",
-        "<li>Cambiar el idioma a portugués: <code>!meeting lang pt</code></li>",
-        "<li>Cambiar el idioma a inglés: <code>!meeting lang en</code></li>",
-        "<li>Cambiar el idioma a francés : <code>!meeting lang fr</code></li>",
-        "<li>Cambiar el idioma a español: <code>!meeting lang es</code></li>",
-        "<li>Cambiar el idioma a alemán: <code>!meeting lang de</code></li>",
-        "</ul>"
-      ],
-      "languageWasChanged": "El idioma ha sido cambiado a <b>{{locale}}</b>.",
-      "meetingWidgetAdded": "<p>Mi tarea está completa.</p><p>El calendario ya ha sido instalado exitosamente en tu sala. Puedes dejar esta sala de chat privada.</p>",
-      "privateRoom": {
-        "inviteReason": "En esta sala privada, el bot puede ayudar a agregar un widget NeoDateFix a la sala '{{originalRoomName}}'.",
-        "name": "Ayuda para {{originalRoomName}}",
-        "topic": "Cómo usar este bot para configurar el widget en la sala {{originalRoomName}}."
       }
     }
+  },
+  "commandErrors": {
+    "badCommand": "Comando incorrecto, intente <code>{{trigger}} help</code>",
+    "badLanguageCode": "El código de idioma no es compatible",
+    "generic": "Hubo un error al procesar su comando: {{message}}",
+    "noCommandProvided": "No se proporcionó ningún comando, intente <code>{{trigger}} help</code>",
+    "noLanguageCode": "No se proporcionó un código de idioma, use uno de estos ({{availableLanguageCodes}})"
+  },
+  "commandHelp": [
+    "<p>Comandos disponibles:</p>",
+    "<ul>",
+    "<li><code>!meeting lang &lt;pt|en|fr|es|de&gt;</code> (Cambiar el idioma del bot en esta sala.)</li>",
+    "<li><code>!meeting setup</code> (Agrega el calendario a la sala.)</li>",
+    "<li><code>!meeting status</code> (Verifica la capacidad para agregar el calendario.)</li>",
+    "</ul>"
+  ],
+  "meeting": {
+    "invite": {
+      "message": "📅 {{range, daterange}}<br/>$t(meeting.invite.messageRecurrence, {\"context\": \"{{recurrenceContext}}\" })<br/>$t(meeting.invite.messageByOrganizer, {\"context\": \"{{organizerContext}}\" })$t(meeting.invite.messageDescription, {\"context\": \"{{descriptionContext}}\" })",
+      "messageByOrganizer_none": "",
+      "messageByOrganizer_present": "\nhas sido invitado a una reunión por {{organizerDisplayName}}",
+      "messageDescription_none": "",
+      "messageDescription_present": "\n<hr><i>{{description}}</i>",
+      "messageRecurrence_none": "",
+      "messageRecurrence_present": "\n🔁 Recurrencia: {{recurrence}}<br/>"
+    },
+    "room": {
+      "notification": {
+        "changed": {
+          "date": {
+            "current": "Fecha: {{range, daterange}}",
+            "previous": "(anteriormente: {{range, daterange}})"
+          },
+          "description": {
+            "current": "Descripción: {{description}}",
+            "previous": "(anteriormente: {{description}})"
+          },
+          "headLine": "CAMBIOS",
+          "occurrence": {
+            "current": "Una reunión de una serie de reuniones se movió a {{range, daterange}}",
+            "deleted": "Una reunión de una serie de reuniones en {{range, daterange}} ha sido eliminada",
+            "previous": "(anteriormente: {{value, daterange}})"
+          },
+          "repetition": {
+            "current": "Repetir reunión: {{repetitionText}}",
+            "previous": "(anteriormente: {{repetitionText}})"
+          },
+          "title": {
+            "current": "Título: {{title}}",
+            "previous": "(anteriormente: {{title}})"
+          }
+        },
+        "closed": {
+          "message": "La sala fue cerrada por el administrador"
+        },
+        "noRepetition": "Sin repetición"
+      }
+    },
+    "user": {
+      "kicked": "El usuario {{userId}} ha sido eliminado por {{sender}}"
+    }
+  },
+  "recurrenceEditor": {
+    "ordinals": {
+      "first": "primero",
+      "fourth": "cuarto",
+      "last": "último",
+      "second": "segundo",
+      "third": "tercero"
+    },
+    "ruleText": {
+      "afterMeetingCount_one": "por una vez",
+      "afterMeetingCount_other": "por {{count}} veces",
+      "daily_one": "Cada día$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "daily_other": "Cada {{count}} días$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_bymonthday_one": "Cada mes en el $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_bymonthday_other": "Cada {{count}} meses en el $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_byweekday_one": "Cada mes en el {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_byweekday_other": "Cada {{count}} meses en el {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_simple_one": "Cada mes$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_simple_other": "Cada {{count}} meses$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "ordinal_ordinal_one": "{{count}}º",
+      "ordinal_ordinal_two": "{{count}}º",
+      "ordinal_ordinal_few": "{{count}}º",
+      "ordinal_ordinal_other": "{{count}}º",
+      "recurrenceEnd_count": " $t(recurrenceEditor.ruleText.afterMeetingCount, {\"count\": {{afterMeetingCount}}, \"ordinal\": false })",
+      "recurrenceEnd_never": "",
+      "recurrenceEnd_until": " hasta {{ untilDate, datetime(year: 'numeric'; month: 'long'; day: 'numeric') }}",
+      "unknown": "Recurrencia no soportada",
+      "weekly_all_one": "Cada semana$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_all_other": "Cada {{count}} semanas$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_some_one": "Cada semana en {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_some_other": "Cada {{count}} semanas en {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_weekdays_one": "Cada día laboral$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_weekdays_other": "Cada {{count}} semanas en días laborales$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_bymonthday_one": "Cada {{monthLabel}} en el $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_bymonthday_other": "Cada {{count}} años en el $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true }) de {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_byweekday_one": "Cada {{monthLabel}} en el {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_byweekday_other": "Cada {{count}} años en el {{ordinalLabel}} {{byweekday}} de {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_simple_one": "Cada año$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_simple_other": "Cada {{count}} años$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })"
+    }
+  },
+  "welcome": {
+    "botIsAdmin": "El bot es un moderador en la sala <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>. Si ingresas el comando <code>!meeting setup</code>, el widget NeoDateFix será añadido a esa sala.",
+    "botNotAdmin": "El bot no es un moderador en la sala <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.",
+    "errors": {
+      "meetingWidgetExists": "No se puede agregar un nuevo widget porque ya existe.",
+      "notEnoughPermissions": "Desafortunadamente, no puedo agregar la función de calendario. No tengo la autorización adecuada. Por favor, dame derechos de moderador en tu sala <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>."
+    },
+    "helpWhenNotAdmin": "Desafortunadamente, no puedo agregar la función de calendario. No tengo la autorización adecuada. Por favor, dame derechos de moderador en tu sala <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.",
+    "intro": [
+      "<p>Hola {{userDisplayName}}, gracias por invitarme a la <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.</p>",
+      "<p>Estaré encantado de ayudarte a configurar tu calendario en esa sala.</p>",
+      "<p>Para que pueda agregar la función de calendario a tu sala, por favor, dame el derecho necesario para agregar widgets a la sala <a href='{{originalRoomLink}}'>{{originalRoomName}}</a> (por ejemplo, el rol de Moderador). Puedes hacerlo en mi perfil de usuario, que puedes encontrar en el menú lateral derecho a través del ícono de \"información\".</p>",
+      "<p>Si no deseas darme los permisos necesarios, puedes agregar la función de calendario a tu sala manualmente enviando el siguiente mensaje a la sala: <code>/addwidget {{widgetURL}}</code></p>",
+      "<p>Para obtener un resumen de todos los comandos, puedes enviar <code>!meeting help</code></p>"
+    ],
+    "introDone": [
+      "<p>Hola {{userDisplayName}}, gracias por invitarme a la <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.</p>",
+      "<p>Mi tarea era ayudarte a configurar el calendario.</p>",
+      "<p>El calendario ya ha sido configurado exitosamente en tu sala. Por lo tanto, ya puedes dejar este chat.</p>",
+      "<p>Para obtener un resumen de todos los comandos, puedes enviar <code>!meeting help</code></p>"
+    ],
+    "introLanguage": [
+      "Información sobre la configuración del idioma: Para habilitar la comunicación en tu idioma, puedes usar los siguientes comandos: ",
+      "<ul>",
+      "<li>Cambiar el idioma a portugués: <code>!meeting lang pt</code></li>",
+      "<li>Cambiar el idioma a inglés: <code>!meeting lang en</code></li>",
+      "<li>Cambiar el idioma a francés : <code>!meeting lang fr</code></li>",
+      "<li>Cambiar el idioma a español: <code>!meeting lang es</code></li>",
+      "<li>Cambiar el idioma a alemán: <code>!meeting lang de</code></li>",
+      "</ul>"
+    ],
+    "languageWasChanged": "El idioma ha sido cambiado a <b>{{locale}}</b>.",
+    "meetingWidgetAdded": "<p>Mi tarea está completa.</p><p>El calendario ya ha sido instalado exitosamente en tu sala. Puedes dejar esta sala de chat privada.</p>",
+    "privateRoom": {
+      "inviteReason": "En esta sala privada, el bot puede ayudar a agregar un widget NeoDateFix a la sala '{{originalRoomName}}'.",
+      "name": "Ayuda para {{originalRoomName}}",
+      "topic": "Cómo usar este bot para configurar el widget en la sala {{originalRoomName}}."
+    }
   }
-  
+}

--- a/matrix-meetings-bot/src/static/locales/es/translation.json
+++ b/matrix-meetings-bot/src/static/locales/es/translation.json
@@ -1,0 +1,159 @@
+{
+    "base": {
+      "exception": {
+        "message": "Ocurrió un error \"{{errorName}}\" al procesar los eventos para la sala {{roomId}} {{roomName}}. <br> Por favor proporcione este número: [{{requestId}}] para más preguntas."
+      }
+    },
+    "bot": {
+      "private": {
+        "errorRoom": {
+          "create": {
+            "message": "Mensajes de error de NeoDateFix-Bot",
+            "topic": "Más detalles"
+          }
+        }
+      }
+    },
+    "commandErrors": {
+      "badCommand": "Comando incorrecto, intente <code>{{trigger}} help</code>",
+      "badLanguageCode": "El código de idioma no es compatible",
+      "generic": "Hubo un error al procesar su comando: {{message}}",
+      "noCommandProvided": "No se proporcionó ningún comando, intente <code>{{trigger}} help</code>",
+      "noLanguageCode": "No se proporcionó un código de idioma, use uno de estos ({{availableLanguageCodes}})"
+    },
+    "commandHelp": [
+      "<p>Comandos disponibles:</p>",
+      "<ul>",
+      "<li><code>!meeting lang &lt;pt|en|fr|es|de&gt;</code> (Cambiar el idioma del bot en esta sala.)</li>",
+      "<li><code>!meeting setup</code> (Agrega el calendario a la sala.)</li>",
+      "<li><code>!meeting status</code> (Verifica la capacidad para agregar el calendario.)</li>",
+      "</ul>"
+    ],
+    "meeting": {
+      "invite": {
+        "message": "📅 {{range, daterange}}<br/>$t(meeting.invite.messageRecurrence, {\"context\": \"{{recurrenceContext}}\" })<br/>$t(meeting.invite.messageByOrganizer, {\"context\": \"{{organizerContext}}\" })$t(meeting.invite.messageDescription, {\"context\": \"{{descriptionContext}}\" })",
+        "messageByOrganizer_none": "",
+        "messageByOrganizer_present": "\nhas sido invitado a una reunión por {{organizerDisplayName}}",
+        "messageDescription_none": "",
+        "messageDescription_present": "\n<hr><i>{{description}}</i>",
+        "messageRecurrence_none": "",
+        "messageRecurrence_present": "\n🔁 Recurrencia: {{recurrence}}<br/>"
+      },
+      "room": {
+        "notification": {
+          "changed": {
+            "date": {
+              "current": "Fecha: {{range, daterange}}",
+              "previous": "(anteriormente: {{range, daterange}})"
+            },
+            "description": {
+              "current": "Descripción: {{description}}",
+              "previous": "(anteriormente: {{description}})"
+            },
+            "headLine": "CAMBIOS",
+            "occurrence": {
+              "current": "Una reunión de una serie de reuniones se movió a {{range, daterange}}",
+              "deleted": "Una reunión de una serie de reuniones en {{range, daterange}} ha sido eliminada",
+              "previous": "(anteriormente: {{value, daterange}})"
+            },
+            "repetition": {
+              "current": "Repetir reunión: {{repetitionText}}",
+              "previous": "(anteriormente: {{repetitionText}})"
+            },
+            "title": {
+              "current": "Título: {{title}}",
+              "previous": "(anteriormente: {{title}})"
+            }
+          },
+          "closed": {
+            "message": "La sala fue cerrada por el administrador"
+          },
+          "noRepetition": "Sin repetición"
+        }
+      },
+      "user": {
+        "kicked": "El usuario {{userId}} ha sido eliminado por {{sender}}"
+      }
+    },
+    "recurrenceEditor": {
+      "ordinals": {
+        "first": "primero",
+        "fourth": "cuarto",
+        "last": "último",
+        "second": "segundo",
+        "third": "tercero"
+      },
+      "ruleText": {
+        "afterMeetingCount_one": "por una vez",
+        "afterMeetingCount_other": "por {{count}} veces",
+        "daily_one": "Cada día$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "daily_other": "Cada {{count}} días$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_bymonthday_one": "Cada mes en el $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_bymonthday_other": "Cada {{count}} meses en el $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_byweekday_one": "Cada mes en el {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_byweekday_other": "Cada {{count}} meses en el {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_simple_one": "Cada mes$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_simple_other": "Cada {{count}} meses$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "ordinal_ordinal_one": "{{count}}º",
+        "ordinal_ordinal_two": "{{count}}º",
+        "ordinal_ordinal_few": "{{count}}º",
+        "ordinal_ordinal_other": "{{count}}º",
+        "recurrenceEnd_count": " $t(recurrenceEditor.ruleText.afterMeetingCount, {\"count\": {{afterMeetingCount}}, \"ordinal\": false })",
+        "recurrenceEnd_never": "",
+        "recurrenceEnd_until": " hasta {{ untilDate, datetime(year: 'numeric'; month: 'long'; day: 'numeric') }}",
+        "unknown": "Recurrencia no soportada",
+        "weekly_all_one": "Cada semana$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "weekly_all_other": "Cada {{count}} semanas$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "weekly_some_one": "Cada semana en {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "weekly_some_other": "Cada {{count}} semanas en {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "weekly_weekdays_one": "Cada día laboral$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "weekly_weekdays_other": "Cada {{count}} semanas en días laborales$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_bymonthday_one": "Cada {{monthLabel}} en el $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_bymonthday_other": "Cada {{count}} años en el $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true }) de {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_byweekday_one": "Cada {{monthLabel}} en el {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_byweekday_other": "Cada {{count}} años en el {{ordinalLabel}} {{byweekday}} de {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_simple_one": "Cada año$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_simple_other": "Cada {{count}} años$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })"
+      }
+    },
+    "welcome": {
+      "botIsAdmin": "El bot es un moderador en la sala <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>. Si ingresas el comando <code>!meeting setup</code>, el widget NeoDateFix será añadido a esa sala.",
+      "botNotAdmin": "El bot no es un moderador en la sala <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.",
+      "errors": {
+        "meetingWidgetExists": "No se puede agregar un nuevo widget porque ya existe.",
+        "notEnoughPermissions": "Desafortunadamente, no puedo agregar la función de calendario. No tengo la autorización adecuada. Por favor, dame derechos de moderador en tu sala <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>."
+      },
+      "helpWhenNotAdmin": "Desafortunadamente, no puedo agregar la función de calendario. No tengo la autorización adecuada. Por favor, dame derechos de moderador en tu sala <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.",
+      "intro": [
+        "<p>Hola {{userDisplayName}}, gracias por invitarme a la <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.</p>",
+        "<p>Estaré encantado de ayudarte a configurar tu calendario en esa sala.</p>",
+        "<p>Para que pueda agregar la función de calendario a tu sala, por favor, dame el derecho necesario para agregar widgets a la sala <a href='{{originalRoomLink}}'>{{originalRoomName}}</a> (por ejemplo, el rol de Moderador). Puedes hacerlo en mi perfil de usuario, que puedes encontrar en el menú lateral derecho a través del ícono de \"información\".</p>",
+        "<p>Si no deseas darme los permisos necesarios, puedes agregar la función de calendario a tu sala manualmente enviando el siguiente mensaje a la sala: <code>/addwidget {{widgetURL}}</code></p>",
+        "<p>Para obtener un resumen de todos los comandos, puedes enviar <code>!meeting help</code></p>"
+      ],
+      "introDone": [
+        "<p>Hola {{userDisplayName}}, gracias por invitarme a la <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.</p>",
+        "<p>Mi tarea era ayudarte a configurar el calendario.</p>",
+        "<p>El calendario ya ha sido configurado exitosamente en tu sala. Por lo tanto, ya puedes dejar este chat.</p>",
+        "<p>Para obtener un resumen de todos los comandos, puedes enviar <code>!meeting help</code></p>"
+      ],
+      "introLanguage": [
+        "Información sobre la configuración del idioma: Para habilitar la comunicación en tu idioma, puedes usar los siguientes comandos: ",
+        "<ul>",
+        "<li>Cambiar el idioma a portugués: <code>!meeting lang pt</code></li>",
+        "<li>Cambiar el idioma a inglés: <code>!meeting lang en</code></li>",
+        "<li>Cambiar el idioma a francés : <code>!meeting lang fr</code></li>",
+        "<li>Cambiar el idioma a español: <code>!meeting lang es</code></li>",
+        "<li>Cambiar el idioma a alemán: <code>!meeting lang de</code></li>",
+        "</ul>"
+      ],
+      "languageWasChanged": "El idioma ha sido cambiado a <b>{{locale}}</b>.",
+      "meetingWidgetAdded": "<p>Mi tarea está completa.</p><p>El calendario ya ha sido instalado exitosamente en tu sala. Puedes dejar esta sala de chat privada.</p>",
+      "privateRoom": {
+        "inviteReason": "En esta sala privada, el bot puede ayudar a agregar un widget NeoDateFix a la sala '{{originalRoomName}}'.",
+        "name": "Ayuda para {{originalRoomName}}",
+        "topic": "Cómo usar este bot para configurar el widget en la sala {{originalRoomName}}."
+      }
+    }
+  }
+  

--- a/matrix-meetings-bot/src/static/locales/es/translation.json
+++ b/matrix-meetings-bot/src/static/locales/es/translation.json
@@ -85,6 +85,7 @@
     },
     "ruleText": {
       "afterMeetingCount_one": "por una vez",
+      "afterMeetingCount_many": "por {{count}} veces",
       "afterMeetingCount_other": "por {{count}} veces",
       "daily_one": "Cada día$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
       "daily_other": "Cada {{count}} días$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",

--- a/matrix-meetings-bot/src/static/locales/fr/translation.json
+++ b/matrix-meetings-bot/src/static/locales/fr/translation.json
@@ -1,159 +1,158 @@
 {
-    "base": {
-      "exception": {
-        "message": "Une erreur \"{{errorName}}\" s’est produite lors que les événements étaient traités dans la salle {{roomId}} {{roomName}}. <br> S’il vous plaît communiquez ce numéro: [{{requestId}}] pour d’autres questions."
-      }
-    },
-    "bot": {
-      "private": {
-        "errorRoom": {
-          "create": {
-            "message": "Messages d’erreur de NeoDateFix-Bot",
-            "topic": "Plus details"
-          }
+  "base": {
+    "exception": {
+      "message": "Une erreur \"{{errorName}}\" s’est produite lors que les événements étaient traités dans la salle {{roomId}} {{roomName}}. <br> S’il vous plaît communiquez ce numéro: [{{requestId}}] pour d’autres questions."
+    }
+  },
+  "bot": {
+    "private": {
+      "errorRoom": {
+        "create": {
+          "message": "Messages d’erreur de NeoDateFix-Bot",
+          "topic": "Plus details"
         }
-      }
-    },
-    "commandErrors": {
-      "badCommand": "Commande incorrecte, essayez <code>{{trigger}} help</code>",
-      "badLanguageCode": "Le langage codé n’est pas supporté",
-      "generic": "Une erreur s’est produite en traitant votre commande: {{message}}",
-      "noCommandProvided": "Aucune commande fournie, essayez <code>{{trigger}} help</code>",
-      "noLanguageCode": "Le langage codé n’est pas fourni, utilisez l’un des langages suivants ({{availableLanguageCodes}})"
-    },
-    "commandHelp": [
-      "<p>Commandes disponibles:</p>",
-      "<ul>",
-      "<li><code>!meeting lang &lt;pt|en|fr|es|de&gt;</code> (Changez la langue du bot dans cette salle.)</li>",
-      "<li><code>!meeting setup</code> (Ajoutez le calendrier à la salle.)</li>",
-      "<li><code>!meeting status</code> (Vérifiez la capacité d’ additionner le calendrier.)</li>",
-      "</ul>"
-    ],
-    "meeting": {
-      "invite": {
-        "message": "📅 {{range, daterange}}<br/>$t(meeting.invite.messageRecurrence, {\"context\": \"{{recurrenceContext}}\" })<br/>$t(meeting.invite.messageByOrganizer, {\"context\": \"{{organizerContext}}\" })$t(meeting.invite.messageDescription, {\"context\": \"{{descriptionContext}}\" })",
-        "messageByOrganizer_none": "",
-        "messageByOrganizer_present": "\nVous avez été invité à participer dans une réunion par {{organizerDisplayName}}",
-        "messageDescription_none": "",
-        "messageDescription_present": "\n<hr><i>{{description}}</i>",
-        "messageRecurrence_none": "",
-        "messageRecurrence_present": "\n🔁 Récurrence: {{recurrence}}<br/>"
-      },
-      "room": {
-        "notification": {
-          "changed": {
-            "date": {
-              "current": "Date: {{range, daterange}}",
-              "previous": "(préalablement: {{range, daterange}})"
-            },
-            "description": {
-              "current": "Description: {{description}}",
-              "previous": "(préalablement: {{description}})"
-            },
-            "headLine": "MODIFICATIONS",
-            "occurrence": {
-              "current": "Une seule réunion d’une série de réunions est changée pour {{range, daterange}}",
-              "deleted": "Une seule réunion d’une série de réunions en {{range, daterange}} est effacée",
-              "previous": "(préalablement: {{value, daterange}})"
-            },
-            "repetition": {
-              "current": "Répéter réunion: {{repetitionText}}",
-              "previous": "(préalablement: {{repetitionText}})"
-            },
-            "title": {
-              "current": "Titre: {{title}}",
-              "previous": "(préalablement: {{title}})"
-            }
-          },
-          "closed": {
-            "message": "La salle a été fermée par l’ administrateur"
-          },
-          "noRepetition": "Sans répétitions"
-        }
-      },
-      "user": {
-        "kicked": "Utilisateur {{userId}} a été supprimé par {{sender}}"
-      }
-    },
-    "recurrenceEditor": {
-      "ordinals": {
-        "first": "premier",
-        "fourth": "quatrième",
-        "last": "dernier",
-        "second": "deuxième",
-        "third": "troisième"
-      },
-      "ruleText": {
-        "afterMeetingCount_one": "pour une fois",
-        "afterMeetingCount_other": "pour {{count}} fois",
-        "daily_one": "Tous les jours$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "daily_other": "Tous {{count}} jours$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_bymonthday_one": "Tous les mois en $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_bymonthday_other": "Tous {{count}} lesmois en $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_byweekday_one": "Tous les mois en {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_byweekday_other": "Tous {{count}} les mois en {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_simple_one": "Tous les mois$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_simple_other": "Tous {{count}} lesmois$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "ordinal_ordinal_one": "{{count}}er",
-        "ordinal_ordinal_two": "{{count}}e",
-        "ordinal_ordinal_few": "{{count}}e",
-        "ordinal_ordinal_other": "{{count}}e",
-        "recurrenceEnd_count": " $t(recurrenceEditor.ruleText.afterMeetingCount, {\"count\": {{afterMeetingCount}}, \"ordinal\": false })",
-        "recurrenceEnd_never": "",
-        "recurrenceEnd_until": " jusqu'à {{ untilDate, datetime(year: 'numeric'; month: 'long'; day: 'numeric') }}",
-        "unknown": "Récurrence non soutenue",
-        "weekly_all_one": "Toutes les semaines$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "weekly_all_other": "Toutes {{count}} les semaines$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "weekly_some_one": "Toutes les semaine en {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "weekly_some_other": "Toutes {{count}} les semaines en {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "weekly_weekdays_one": "Tous les jours de semaine$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "weekly_weekdays_other": "Tous {{count}} les jours de semaine$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_bymonthday_one": "Tous {{monthLabel}} en $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_bymonthday_other": "Tous {{count}} les années en $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true }) de {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_byweekday_one": "Tous {{monthLabel}} en {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_byweekday_other": "Tous {{count}} années en {{ordinalLabel}} {{byweekday}} de {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_simple_one": "Toutes les années$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_simple_other": "Tous {{count}} années$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })"
-      }
-    },
-    "welcome": {
-      "botIsAdmin": "Le bot est un modérateur dans la salle <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>. Si vous introduissez la commande <code>!meeting setup</code>, le widget NeoDateFix sera additionné à la salle.",
-      "botNotAdmin": "Le bot n’est pas un modérateur dans la salle <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.",
-      "errors": {
-        "meetingWidgetExists": "Impossible d’ additionner un nouveau widget parce qu’il existe déjà.",
-        "notEnoughPermissions": "Malheureusement, je n’arrive pas à additionner la fonctionnalité du calendrier. Je n’ai pas l’autorisation nécessaire. S’il vous plaît pourriez-vous me donner les droits de modérateur dans votre salle <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>."
-      },
-      "helpWhenNotAdmin": "Malheureusement, je n’arrive pas à additionner la fonctionnalité du calendrier. Je n’ai pas l’autorisation nécessaire. S’il vous plaît pourriez-vous me donner les droits de modérateur dans votre salle <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.",
-      "intro": [
-        "<p>Bonjour {{userDisplayName}}, je vous remercie de m’avoir invité à <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.</p>",
-        "<p>J’aimerais bien de vous aider à mettre le calendrier dans cette salle.</p>",
-        "<p>Pour que je puisse additionner la fonction du calendrier dans votre salle, s’il vous plaît pourriez-vous me donner la permission necessaire pour additionner les widgets dans votre salle <a href='{{originalRoomLink}}'>{{originalRoomName}}</a> (La fonction de modérateur, par exemple). Vous pouvez le faire dans dans mon profil d’ utilisateur qui se trouve dans no menu du côté droit atravers de \"info\".</p>",
-        "<p>Si vous ne souhaitez pas me donner les autorisations nécessaires, vous pouvez ajouter manuellement la fonction calendrier à votre salle en envoyant le message suivant dans la salle : <code>/addwidget {{widgetURL}}</code></p>",
-        "<p>Pour obtenir un aperçu de toutes les commandes, vous pouvez envoyer <code>!meeting help</code></p>"
-      ],
-      "introDone": [
-        "<p>Bonjour {{userDisplayName}}, je vous remercie de m’avoir invité à <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.</p>",
-        "<p>Ma fonction a été de vous aider à installer le calendrier.</p>",
-        "<p>Le calendrier a été déjà installé avec sucèss dans votre salle. Ainsi, vous pouvez déjà laisser ce chat-box.</p>",
-        "<p>Pour avoir une vision générale des commandes vous pouvez envoyer <code>!meeting help</code></p>"
-      ],
-      "introLanguage": [
-        "Information sur les définitions de la langue: Pour possibiliter la communication dans votre langue, vous pouvez utiliser les commandes suivantes: ",
-        "<ul>",
-        "<li>Changer la langue pour Portugais: <code>!meeting lang pt</code></li>",
-        "<li>Changer la langue pour Anglais: <code>!meeting lang en</code></li>",
-        "<li>Changer la langue pour Français : <code>!meeting lang fr</code></li>",
-        "<li>Changer la langue pour Espagnol: <code>!meeting lang es</code></li>",
-        "<li>Changer la langue pour Allemand: <code>!meeting lang de</code></li>",
-        "</ul>"
-      ],
-      "languageWasChanged": "La langue a été changée pour <b>{{locale}}</b>.",
-      "meetingWidgetAdded": "<p>Ma fonction est accomplie.</p><p>Le calendrier a été déjà  installé dans votre salle avec succès. Vous pouvez déjà sortir de cette salle privée de chat.</p>",
-      "privateRoom": {
-        "inviteReason": "Dans cette salle privée, le bot peut aider à ajouter un widget NeoDateFix à la salle '{{originalRoomName}}'.",
-        "name": "Aide pour {{originalRoomName}}",
-        "topic": "Comme utiliser ce “bot” pour installer le widget bot dans la salle {{originalRoomName}}."
       }
     }
+  },
+  "commandErrors": {
+    "badCommand": "Commande incorrecte, essayez <code>{{trigger}} help</code>",
+    "badLanguageCode": "Le langage codé n’est pas supporté",
+    "generic": "Une erreur s’est produite en traitant votre commande: {{message}}",
+    "noCommandProvided": "Aucune commande fournie, essayez <code>{{trigger}} help</code>",
+    "noLanguageCode": "Le langage codé n’est pas fourni, utilisez l’un des langages suivants ({{availableLanguageCodes}})"
+  },
+  "commandHelp": [
+    "<p>Commandes disponibles:</p>",
+    "<ul>",
+    "<li><code>!meeting lang &lt;pt|en|fr|es|de&gt;</code> (Changez la langue du bot dans cette salle.)</li>",
+    "<li><code>!meeting setup</code> (Ajoutez le calendrier à la salle.)</li>",
+    "<li><code>!meeting status</code> (Vérifiez la capacité d’ additionner le calendrier.)</li>",
+    "</ul>"
+  ],
+  "meeting": {
+    "invite": {
+      "message": "📅 {{range, daterange}}<br/>$t(meeting.invite.messageRecurrence, {\"context\": \"{{recurrenceContext}}\" })<br/>$t(meeting.invite.messageByOrganizer, {\"context\": \"{{organizerContext}}\" })$t(meeting.invite.messageDescription, {\"context\": \"{{descriptionContext}}\" })",
+      "messageByOrganizer_none": "",
+      "messageByOrganizer_present": "\nVous avez été invité à participer dans une réunion par {{organizerDisplayName}}",
+      "messageDescription_none": "",
+      "messageDescription_present": "\n<hr><i>{{description}}</i>",
+      "messageRecurrence_none": "",
+      "messageRecurrence_present": "\n🔁 Récurrence: {{recurrence}}<br/>"
+    },
+    "room": {
+      "notification": {
+        "changed": {
+          "date": {
+            "current": "Date: {{range, daterange}}",
+            "previous": "(préalablement: {{range, daterange}})"
+          },
+          "description": {
+            "current": "Description: {{description}}",
+            "previous": "(préalablement: {{description}})"
+          },
+          "headLine": "MODIFICATIONS",
+          "occurrence": {
+            "current": "Une seule réunion d’une série de réunions est changée pour {{range, daterange}}",
+            "deleted": "Une seule réunion d’une série de réunions en {{range, daterange}} est effacée",
+            "previous": "(préalablement: {{value, daterange}})"
+          },
+          "repetition": {
+            "current": "Répéter réunion: {{repetitionText}}",
+            "previous": "(préalablement: {{repetitionText}})"
+          },
+          "title": {
+            "current": "Titre: {{title}}",
+            "previous": "(préalablement: {{title}})"
+          }
+        },
+        "closed": {
+          "message": "La salle a été fermée par l’ administrateur"
+        },
+        "noRepetition": "Sans répétitions"
+      }
+    },
+    "user": {
+      "kicked": "Utilisateur {{userId}} a été supprimé par {{sender}}"
+    }
+  },
+  "recurrenceEditor": {
+    "ordinals": {
+      "first": "premier",
+      "fourth": "quatrième",
+      "last": "dernier",
+      "second": "deuxième",
+      "third": "troisième"
+    },
+    "ruleText": {
+      "afterMeetingCount_one": "pour une fois",
+      "afterMeetingCount_other": "pour {{count}} fois",
+      "daily_one": "Tous les jours$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "daily_other": "Tous {{count}} jours$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_bymonthday_one": "Tous les mois en $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_bymonthday_other": "Tous {{count}} lesmois en $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_byweekday_one": "Tous les mois en {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_byweekday_other": "Tous {{count}} les mois en {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_simple_one": "Tous les mois$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_simple_other": "Tous {{count}} lesmois$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "ordinal_ordinal_one": "{{count}}er",
+      "ordinal_ordinal_two": "{{count}}e",
+      "ordinal_ordinal_few": "{{count}}e",
+      "ordinal_ordinal_other": "{{count}}e",
+      "recurrenceEnd_count": " $t(recurrenceEditor.ruleText.afterMeetingCount, {\"count\": {{afterMeetingCount}}, \"ordinal\": false })",
+      "recurrenceEnd_never": "",
+      "recurrenceEnd_until": " jusqu'à {{ untilDate, datetime(year: 'numeric'; month: 'long'; day: 'numeric') }}",
+      "unknown": "Récurrence non soutenue",
+      "weekly_all_one": "Toutes les semaines$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_all_other": "Toutes {{count}} les semaines$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_some_one": "Toutes les semaine en {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_some_other": "Toutes {{count}} les semaines en {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_weekdays_one": "Tous les jours de semaine$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_weekdays_other": "Tous {{count}} les jours de semaine$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_bymonthday_one": "Tous {{monthLabel}} en $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_bymonthday_other": "Tous {{count}} les années en $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true }) de {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_byweekday_one": "Tous {{monthLabel}} en {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_byweekday_other": "Tous {{count}} années en {{ordinalLabel}} {{byweekday}} de {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_simple_one": "Toutes les années$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_simple_other": "Tous {{count}} années$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })"
+    }
+  },
+  "welcome": {
+    "botIsAdmin": "Le bot est un modérateur dans la salle <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>. Si vous introduissez la commande <code>!meeting setup</code>, le widget NeoDateFix sera additionné à la salle.",
+    "botNotAdmin": "Le bot n’est pas un modérateur dans la salle <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.",
+    "errors": {
+      "meetingWidgetExists": "Impossible d’ additionner un nouveau widget parce qu’il existe déjà.",
+      "notEnoughPermissions": "Malheureusement, je n’arrive pas à additionner la fonctionnalité du calendrier. Je n’ai pas l’autorisation nécessaire. S’il vous plaît pourriez-vous me donner les droits de modérateur dans votre salle <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>."
+    },
+    "helpWhenNotAdmin": "Malheureusement, je n’arrive pas à additionner la fonctionnalité du calendrier. Je n’ai pas l’autorisation nécessaire. S’il vous plaît pourriez-vous me donner les droits de modérateur dans votre salle <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.",
+    "intro": [
+      "<p>Bonjour {{userDisplayName}}, je vous remercie de m’avoir invité à <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.</p>",
+      "<p>J’aimerais bien de vous aider à mettre le calendrier dans cette salle.</p>",
+      "<p>Pour que je puisse additionner la fonction du calendrier dans votre salle, s’il vous plaît pourriez-vous me donner la permission necessaire pour additionner les widgets dans votre salle <a href='{{originalRoomLink}}'>{{originalRoomName}}</a> (La fonction de modérateur, par exemple). Vous pouvez le faire dans dans mon profil d’ utilisateur qui se trouve dans no menu du côté droit atravers de \"info\".</p>",
+      "<p>Si vous ne souhaitez pas me donner les autorisations nécessaires, vous pouvez ajouter manuellement la fonction calendrier à votre salle en envoyant le message suivant dans la salle : <code>/addwidget {{widgetURL}}</code></p>",
+      "<p>Pour obtenir un aperçu de toutes les commandes, vous pouvez envoyer <code>!meeting help</code></p>"
+    ],
+    "introDone": [
+      "<p>Bonjour {{userDisplayName}}, je vous remercie de m’avoir invité à <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.</p>",
+      "<p>Ma fonction a été de vous aider à installer le calendrier.</p>",
+      "<p>Le calendrier a été déjà installé avec sucèss dans votre salle. Ainsi, vous pouvez déjà laisser ce chat-box.</p>",
+      "<p>Pour avoir une vision générale des commandes vous pouvez envoyer <code>!meeting help</code></p>"
+    ],
+    "introLanguage": [
+      "Information sur les définitions de la langue: Pour possibiliter la communication dans votre langue, vous pouvez utiliser les commandes suivantes: ",
+      "<ul>",
+      "<li>Changer la langue pour Portugais: <code>!meeting lang pt</code></li>",
+      "<li>Changer la langue pour Anglais: <code>!meeting lang en</code></li>",
+      "<li>Changer la langue pour Français : <code>!meeting lang fr</code></li>",
+      "<li>Changer la langue pour Espagnol: <code>!meeting lang es</code></li>",
+      "<li>Changer la langue pour Allemand: <code>!meeting lang de</code></li>",
+      "</ul>"
+    ],
+    "languageWasChanged": "La langue a été changée pour <b>{{locale}}</b>.",
+    "meetingWidgetAdded": "<p>Ma fonction est accomplie.</p><p>Le calendrier a été déjà  installé dans votre salle avec succès. Vous pouvez déjà sortir de cette salle privée de chat.</p>",
+    "privateRoom": {
+      "inviteReason": "Dans cette salle privée, le bot peut aider à ajouter un widget NeoDateFix à la salle '{{originalRoomName}}'.",
+      "name": "Aide pour {{originalRoomName}}",
+      "topic": "Comme utiliser ce “bot” pour installer le widget bot dans la salle {{originalRoomName}}."
+    }
   }
-  
+}

--- a/matrix-meetings-bot/src/static/locales/fr/translation.json
+++ b/matrix-meetings-bot/src/static/locales/fr/translation.json
@@ -1,0 +1,159 @@
+{
+    "base": {
+      "exception": {
+        "message": "Une erreur \"{{errorName}}\" s’est produite lors que les événements étaient traités dans la salle {{roomId}} {{roomName}}. <br> S’il vous plaît communiquez ce numéro: [{{requestId}}] pour d’autres questions."
+      }
+    },
+    "bot": {
+      "private": {
+        "errorRoom": {
+          "create": {
+            "message": "Messages d’erreur de NeoDateFix-Bot",
+            "topic": "Plus details"
+          }
+        }
+      }
+    },
+    "commandErrors": {
+      "badCommand": "Commande incorrecte, essayez <code>{{trigger}} help</code>",
+      "badLanguageCode": "Le langage codé n’est pas supporté",
+      "generic": "Une erreur s’est produite en traitant votre commande: {{message}}",
+      "noCommandProvided": "Aucune commande fournie, essayez <code>{{trigger}} help</code>",
+      "noLanguageCode": "Le langage codé n’est pas fourni, utilisez l’un des langages suivants ({{availableLanguageCodes}})"
+    },
+    "commandHelp": [
+      "<p>Commandes disponibles:</p>",
+      "<ul>",
+      "<li><code>!meeting lang &lt;pt|en|fr|es|de&gt;</code> (Changez la langue du bot dans cette salle.)</li>",
+      "<li><code>!meeting setup</code> (Ajoutez le calendrier à la salle.)</li>",
+      "<li><code>!meeting status</code> (Vérifiez la capacité d’ additionner le calendrier.)</li>",
+      "</ul>"
+    ],
+    "meeting": {
+      "invite": {
+        "message": "📅 {{range, daterange}}<br/>$t(meeting.invite.messageRecurrence, {\"context\": \"{{recurrenceContext}}\" })<br/>$t(meeting.invite.messageByOrganizer, {\"context\": \"{{organizerContext}}\" })$t(meeting.invite.messageDescription, {\"context\": \"{{descriptionContext}}\" })",
+        "messageByOrganizer_none": "",
+        "messageByOrganizer_present": "\nVous avez été invité à participer dans une réunion par {{organizerDisplayName}}",
+        "messageDescription_none": "",
+        "messageDescription_present": "\n<hr><i>{{description}}</i>",
+        "messageRecurrence_none": "",
+        "messageRecurrence_present": "\n🔁 Récurrence: {{recurrence}}<br/>"
+      },
+      "room": {
+        "notification": {
+          "changed": {
+            "date": {
+              "current": "Date: {{range, daterange}}",
+              "previous": "(préalablement: {{range, daterange}})"
+            },
+            "description": {
+              "current": "Description: {{description}}",
+              "previous": "(préalablement: {{description}})"
+            },
+            "headLine": "MODIFICATIONS",
+            "occurrence": {
+              "current": "Une seule réunion d’une série de réunions est changée pour {{range, daterange}}",
+              "deleted": "Une seule réunion d’une série de réunions en {{range, daterange}} est effacée",
+              "previous": "(préalablement: {{value, daterange}})"
+            },
+            "repetition": {
+              "current": "Répéter réunion: {{repetitionText}}",
+              "previous": "(préalablement: {{repetitionText}})"
+            },
+            "title": {
+              "current": "Titre: {{title}}",
+              "previous": "(préalablement: {{title}})"
+            }
+          },
+          "closed": {
+            "message": "La salle a été fermée par l’ administrateur"
+          },
+          "noRepetition": "Sans répétitions"
+        }
+      },
+      "user": {
+        "kicked": "Utilisateur {{userId}} a été supprimé par {{sender}}"
+      }
+    },
+    "recurrenceEditor": {
+      "ordinals": {
+        "first": "premier",
+        "fourth": "quatrième",
+        "last": "dernier",
+        "second": "deuxième",
+        "third": "troisième"
+      },
+      "ruleText": {
+        "afterMeetingCount_one": "pour une fois",
+        "afterMeetingCount_other": "pour {{count}} fois",
+        "daily_one": "Tous les jours$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "daily_other": "Tous {{count}} jours$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_bymonthday_one": "Tous les mois en $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_bymonthday_other": "Tous {{count}} lesmois en $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_byweekday_one": "Tous les mois en {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_byweekday_other": "Tous {{count}} les mois en {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_simple_one": "Tous les mois$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_simple_other": "Tous {{count}} lesmois$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "ordinal_ordinal_one": "{{count}}er",
+        "ordinal_ordinal_two": "{{count}}e",
+        "ordinal_ordinal_few": "{{count}}e",
+        "ordinal_ordinal_other": "{{count}}e",
+        "recurrenceEnd_count": " $t(recurrenceEditor.ruleText.afterMeetingCount, {\"count\": {{afterMeetingCount}}, \"ordinal\": false })",
+        "recurrenceEnd_never": "",
+        "recurrenceEnd_until": " jusqu'à {{ untilDate, datetime(year: 'numeric'; month: 'long'; day: 'numeric') }}",
+        "unknown": "Récurrence non soutenue",
+        "weekly_all_one": "Toutes les semaines$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "weekly_all_other": "Toutes {{count}} les semaines$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "weekly_some_one": "Toutes les semaine en {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "weekly_some_other": "Toutes {{count}} les semaines en {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "weekly_weekdays_one": "Tous les jours de semaine$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "weekly_weekdays_other": "Tous {{count}} les jours de semaine$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_bymonthday_one": "Tous {{monthLabel}} en $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_bymonthday_other": "Tous {{count}} les années en $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true }) de {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_byweekday_one": "Tous {{monthLabel}} en {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_byweekday_other": "Tous {{count}} années en {{ordinalLabel}} {{byweekday}} de {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_simple_one": "Toutes les années$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_simple_other": "Tous {{count}} années$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })"
+      }
+    },
+    "welcome": {
+      "botIsAdmin": "Le bot est un modérateur dans la salle <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>. Si vous introduissez la commande <code>!meeting setup</code>, le widget NeoDateFix sera additionné à la salle.",
+      "botNotAdmin": "Le bot n’est pas un modérateur dans la salle <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.",
+      "errors": {
+        "meetingWidgetExists": "Impossible d’ additionner un nouveau widget parce qu’il existe déjà.",
+        "notEnoughPermissions": "Malheureusement, je n’arrive pas à additionner la fonctionnalité du calendrier. Je n’ai pas l’autorisation nécessaire. S’il vous plaît pourriez-vous me donner les droits de modérateur dans votre salle <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>."
+      },
+      "helpWhenNotAdmin": "Malheureusement, je n’arrive pas à additionner la fonctionnalité du calendrier. Je n’ai pas l’autorisation nécessaire. S’il vous plaît pourriez-vous me donner les droits de modérateur dans votre salle <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.",
+      "intro": [
+        "<p>Bonjour {{userDisplayName}}, je vous remercie de m’avoir invité à <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.</p>",
+        "<p>J’aimerais bien de vous aider à mettre le calendrier dans cette salle.</p>",
+        "<p>Pour que je puisse additionner la fonction du calendrier dans votre salle, s’il vous plaît pourriez-vous me donner la permission necessaire pour additionner les widgets dans votre salle <a href='{{originalRoomLink}}'>{{originalRoomName}}</a> (La fonction de modérateur, par exemple). Vous pouvez le faire dans dans mon profil d’ utilisateur qui se trouve dans no menu du côté droit atravers de \"info\".</p>",
+        "<p>Si vous ne souhaitez pas me donner les autorisations nécessaires, vous pouvez ajouter manuellement la fonction calendrier à votre salle en envoyant le message suivant dans la salle : <code>/addwidget {{widgetURL}}</code></p>",
+        "<p>Pour obtenir un aperçu de toutes les commandes, vous pouvez envoyer <code>!meeting help</code></p>"
+      ],
+      "introDone": [
+        "<p>Bonjour {{userDisplayName}}, je vous remercie de m’avoir invité à <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.</p>",
+        "<p>Ma fonction a été de vous aider à installer le calendrier.</p>",
+        "<p>Le calendrier a été déjà installé avec sucèss dans votre salle. Ainsi, vous pouvez déjà laisser ce chat-box.</p>",
+        "<p>Pour avoir une vision générale des commandes vous pouvez envoyer <code>!meeting help</code></p>"
+      ],
+      "introLanguage": [
+        "Information sur les définitions de la langue: Pour possibiliter la communication dans votre langue, vous pouvez utiliser les commandes suivantes: ",
+        "<ul>",
+        "<li>Changer la langue pour Portugais: <code>!meeting lang pt</code></li>",
+        "<li>Changer la langue pour Anglais: <code>!meeting lang en</code></li>",
+        "<li>Changer la langue pour Français : <code>!meeting lang fr</code></li>",
+        "<li>Changer la langue pour Espagnol: <code>!meeting lang es</code></li>",
+        "<li>Changer la langue pour Allemand: <code>!meeting lang de</code></li>",
+        "</ul>"
+      ],
+      "languageWasChanged": "La langue a été changée pour <b>{{locale}}</b>.",
+      "meetingWidgetAdded": "<p>Ma fonction est accomplie.</p><p>Le calendrier a été déjà  installé dans votre salle avec succès. Vous pouvez déjà sortir de cette salle privée de chat.</p>",
+      "privateRoom": {
+        "inviteReason": "Dans cette salle privée, le bot peut aider à ajouter un widget NeoDateFix à la salle '{{originalRoomName}}'.",
+        "name": "Aide pour {{originalRoomName}}",
+        "topic": "Comme utiliser ce “bot” pour installer le widget bot dans la salle {{originalRoomName}}."
+      }
+    }
+  }
+  

--- a/matrix-meetings-bot/src/static/locales/fr/translation.json
+++ b/matrix-meetings-bot/src/static/locales/fr/translation.json
@@ -85,6 +85,7 @@
     },
     "ruleText": {
       "afterMeetingCount_one": "pour une fois",
+      "afterMeetingCount_many": "pour {{count}} fois",
       "afterMeetingCount_other": "pour {{count}} fois",
       "daily_one": "Tous les jours$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
       "daily_other": "Tous {{count}} jours$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",

--- a/matrix-meetings-bot/src/static/locales/pt/translation.json
+++ b/matrix-meetings-bot/src/static/locales/pt/translation.json
@@ -85,6 +85,7 @@
     },
     "ruleText": {
       "afterMeetingCount_one": "uma vez",
+      "afterMeetingCount_many": "por {{count}} vezes",
       "afterMeetingCount_other": "por {{count}} vezes",
       "daily_one": "Todos os dias$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
       "daily_other": "Todos {{count}} dias$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",

--- a/matrix-meetings-bot/src/static/locales/pt/translation.json
+++ b/matrix-meetings-bot/src/static/locales/pt/translation.json
@@ -1,159 +1,158 @@
 {
-    "base": {
-      "exception": {
-        "message": "Um erro \"{{errorName}}\" ocorreu enquanto se processavam os eventos na sala {{roomId}} {{roomName}}. <br> Por favor forneça este número: [{{requestId}}] para mais questões."
-      }
-    },
-    "bot": {
-      "private": {
-        "errorRoom": {
-          "create": {
-            "message": "Mensagens de erro de NeoDateFix-Bot",
-            "topic": "Mais detalhes"
-          }
+  "base": {
+    "exception": {
+      "message": "Um erro \"{{errorName}}\" ocorreu enquanto se processavam os eventos na sala {{roomId}} {{roomName}}. <br> Por favor forneça este número: [{{requestId}}] para mais questões."
+    }
+  },
+  "bot": {
+    "private": {
+      "errorRoom": {
+        "create": {
+          "message": "Mensagens de erro de NeoDateFix-Bot",
+          "topic": "Mais detalhes"
         }
-      }
-    },
-    "commandErrors": {
-      "badCommand": "Comando incorreto, tente <code>{{trigger}} help</code>",
-      "badLanguageCode": "A linguagem de código não é suportada",
-      "generic": "Ocorreu um erro ao processar o seu comando: {{message}}",
-      "noCommandProvided": "Nenhum comando fornecido, tente <code>{{trigger}} help</code>",
-      "noLanguageCode": "A linguagem de código não é fornecida, use uma das seguintes ({{availableLanguageCodes}})"
-    },
-    "commandHelp": [
-      "<p>Comandos disponíveis:</p>",
-      "<ul>",
-      "<li><code>!meeting lang &lt;pt|en|fr|es|de&gt;</code> (Mude o idioma do bot nesta sala.)</li>",
-      "<li><code>!meeting setup</code> (Adiciona o calendário à sala.)</li>",
-      "<li><code>!meeting status</code> (Verifica a capacidade de adicionar o calendário.)</li>",
-      "</ul>"
-    ],
-    "meeting": {
-      "invite": {
-        "message": "📅 {{range, daterange}}<br/>$t(meeting.invite.messageRecurrence, {\"context\": \"{{recurrenceContext}}\" })<br/>$t(meeting.invite.messageByOrganizer, {\"context\": \"{{organizerContext}}\" })$t(meeting.invite.messageDescription, {\"context\": \"{{descriptionContext}}\" })",
-        "messageByOrganizer_none": "",
-        "messageByOrganizer_present": "\nverifica a capacidade de adicionar o calendário {{organizerDisplayName}}",
-        "messageDescription_none": "",
-        "messageDescription_present": "\n<hr><i>{{description}}</i>",
-        "messageRecurrence_none": "",
-        "messageRecurrence_present": "\n🔁 Recorrência: {{recurrence}}<br/>"
-      },
-      "room": {
-        "notification": {
-          "changed": {
-            "date": {
-              "current": "Data: {{range, daterange}}",
-              "previous": "(previamente: {{range, daterange}})"
-            },
-            "description": {
-              "current": "Descrição: {{description}}",
-              "previous": "(previamente: {{description}})"
-            },
-            "headLine": "ALTERAÇÕES",
-            "occurrence": {
-              "current": "Uma só reunião de uma série de reuniões é mudada para {{range, daterange}}",
-              "deleted": "Uma só reunião de uma série de reuniões é {{range, daterange}} apagada",
-              "previous": "(previamente: {{value, daterange}})"
-            },
-            "repetition": {
-              "current": "Repetir reunião: {{repetitionText}}",
-              "previous": "(previamente: {{repetitionText}})"
-            },
-            "title": {
-              "current": "Título: {{title}}",
-              "previous": "(previamente: {{title}})"
-            }
-          },
-          "closed": {
-            "message": "A sala foi fechada pelo administrador"
-          },
-          "noRepetition": "Sem repetição"
-        }
-      },
-      "user": {
-        "kicked": "Utilizador {{userId}} foi removido pelo {{sender}}"
-      }
-    },
-    "recurrenceEditor": {
-      "ordinals": {
-        "first": "primeiro",
-        "fourth": "quarto",
-        "last": "último",
-        "second": "segundo",
-        "third": "terceiro"
-      },
-      "ruleText": {
-        "afterMeetingCount_one": "uma vez",
-        "afterMeetingCount_other": "por {{count}} vezes",
-        "daily_one": "Todos os dias$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "daily_other": "Todos {{count}} dias$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_bymonthday_one": "Todos os meses em $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_bymonthday_other": "Todos {{count}} os meses em $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_byweekday_one": "Todos os meses em {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_byweekday_other": "Todos {{count}} os meses em {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_simple_one": "Todos os meses$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_simple_other": "Todos {{count}} meses$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "ordinal_ordinal_one": "{{count}}º",
-        "ordinal_ordinal_two": "{{count}}º",
-        "ordinal_ordinal_few": "{{count}}º",
-        "ordinal_ordinal_other": "{{count}}º",
-        "recurrenceEnd_count": "$t(recurrenceEditor.ruleText.afterMeetingCount, {\"count\": {{afterMeetingCount}}, \"ordinal\": false })",
-        "recurrenceEnd_never": "",
-        "recurrenceEnd_until": " até {{ untilDate, datetime(year: 'numeric'; month: 'long'; day: 'numeric') }}",
-        "unknown": "Recorrência não suportada",
-        "weekly_all_one": "Todas as semanas $t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "weekly_all_other": "Todas {{count}} as semanas $t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "weekly_some_one": "Todas as semanas em {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "weekly_some_other": "Todas {{count}} as semanas em {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "weekly_weekdays_one": "Todos os dias de semana$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "weekly_weekdays_other": "Todas {{count}} semanas nos os dias de semana$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_bymonthday_one": "Todos {{monthLabel}} em $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_bymonthday_other": "Todos {{count}} anos em $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true }) de {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_byweekday_one": "Todos {{monthLabel}} em {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_byweekday_other": "Todos {{count}} anos em {{ordinalLabel}} {{byweekday}} de {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_simple_one": "Todos os anos$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_simple_other": "Todos {{count}} anos$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })"
-      }
-    },
-    "welcome": {
-      "botIsAdmin": "O bot é um moderador na sala <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>. Se introduzir o comando <code>!meeting setup</code>, o widget NeoDateFix será adicionado à sala.",
-      "botNotAdmin": "O bot não é um moderador na sala <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.",
-      "errors": {
-        "meetingWidgetExists": "Impossível adicionar um novo widget porque já existe.",
-        "notEnoughPermissions": "Infelizmente, não consigo adicionar a funcionalidade do calendário. Não tenho a permissão necessária. Por favor dê-me direitos de moderador na sua sala <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>."
-      },
-      "helpWhenNotAdmin": "Infelizmente, não consigo adicionar a funcionalidade do calendário. Não tenho a permissão necessária. Por favor dê-me direitos de moderador na sua sala <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.",
-      "intro": [
-        "<p>Olá {{userDisplayName}}, obrigado por me convidar para <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.</p>",
-        "<p>Gostaria muito de o ajudar a colocar o calendário naquela sala.</p>",
-        "<p>Para que eu possa adicionar a função do calendário à sua sala, por favor dê-me a permissão necessária para adicionar widgets à sua sala <a href='{{originalRoomLink}}'>{{originalRoomName}}</a> (A função de moderador, por exemplo). Pode fazê-lo no meu perfil de utilizador que encontra no menu do lado direito através de \"info\"-icon.</p>",
-        "<p>Se não me quiser dar a autorização necessária, pode adicionar a funcionalidade do calendário à sua sala manualmente, enviando a seguinte mensagem para a sala: <code>/addwidget {{widgetURL}}</code></p>",
-        "<p>Para ter uma vista geral dos comandos pode enviar <code>!meeting help</code></p>"
-      ],
-      "introDone": [
-        "<p>Olá {{userDisplayName}}, obrigado por me convidar para <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.</p>",
-        "<p>A minha função foi ajudá-lo a instalar o calendário.</p>",
-        "<p>O calendário já foi instalado com sucesso na sua sala. Assim, já pode deixar esta caixa de chat.</p>",
-        "<p>Para ter uma vista geral dos comandos pode enviar <code>!meeting help</code></p>"
-      ],
-      "introLanguage": [
-        "Informação sobre as definições de idioma: Para possibilitar a comunicação na sua língua, pode usar os seguintes comandos: ",
-        "<ul>",
-        "<li>Mudar o idioma para Português: <code>!meeting lang pt</code></li>",
-        "<li>Mudar o idioma para Inglês: <code>!meeting lang en</code></li>",
-        "<li>Mudar o idioma para Francês: <code>!meeting lang fr</code></li>",
-        "<li>Mudar o idioma para Espanhol: <code>!meeting lang es</code></li>",
-        "<li>Mudar o idioma para Alemão: <code>!meeting lang de</code></li>",
-        "</ul>"
-      ],
-      "languageWasChanged": "O idioma foi alterado para <b>{{locale}}</b>.",
-      "meetingWidgetAdded": "<p>A minha função está cumprida.</p><p>O calendário já foi instalado na sua sala com sucesso. Já pode sair desta sala privada de chat.</p>",
-      "privateRoom": {
-        "inviteReason": "Nesta sala privada, o “bot” pode ajudar a adicionar um NeoDateFix widget à sala '{{originalRoomName}}'.",
-        "name": "Ajuda para {{originalRoomName}}",
-        "topic": "Como usar este “bot” para adicionar o widget bot na sala {{originalRoomName}}."
       }
     }
+  },
+  "commandErrors": {
+    "badCommand": "Comando incorreto, tente <code>{{trigger}} help</code>",
+    "badLanguageCode": "A linguagem de código não é suportada",
+    "generic": "Ocorreu um erro ao processar o seu comando: {{message}}",
+    "noCommandProvided": "Nenhum comando fornecido, tente <code>{{trigger}} help</code>",
+    "noLanguageCode": "A linguagem de código não é fornecida, use uma das seguintes ({{availableLanguageCodes}})"
+  },
+  "commandHelp": [
+    "<p>Comandos disponíveis:</p>",
+    "<ul>",
+    "<li><code>!meeting lang &lt;pt|en|fr|es|de&gt;</code> (Mude o idioma do bot nesta sala.)</li>",
+    "<li><code>!meeting setup</code> (Adiciona o calendário à sala.)</li>",
+    "<li><code>!meeting status</code> (Verifica a capacidade de adicionar o calendário.)</li>",
+    "</ul>"
+  ],
+  "meeting": {
+    "invite": {
+      "message": "📅 {{range, daterange}}<br/>$t(meeting.invite.messageRecurrence, {\"context\": \"{{recurrenceContext}}\" })<br/>$t(meeting.invite.messageByOrganizer, {\"context\": \"{{organizerContext}}\" })$t(meeting.invite.messageDescription, {\"context\": \"{{descriptionContext}}\" })",
+      "messageByOrganizer_none": "",
+      "messageByOrganizer_present": "\nverifica a capacidade de adicionar o calendário {{organizerDisplayName}}",
+      "messageDescription_none": "",
+      "messageDescription_present": "\n<hr><i>{{description}}</i>",
+      "messageRecurrence_none": "",
+      "messageRecurrence_present": "\n🔁 Recorrência: {{recurrence}}<br/>"
+    },
+    "room": {
+      "notification": {
+        "changed": {
+          "date": {
+            "current": "Data: {{range, daterange}}",
+            "previous": "(previamente: {{range, daterange}})"
+          },
+          "description": {
+            "current": "Descrição: {{description}}",
+            "previous": "(previamente: {{description}})"
+          },
+          "headLine": "ALTERAÇÕES",
+          "occurrence": {
+            "current": "Uma só reunião de uma série de reuniões é mudada para {{range, daterange}}",
+            "deleted": "Uma só reunião de uma série de reuniões é {{range, daterange}} apagada",
+            "previous": "(previamente: {{value, daterange}})"
+          },
+          "repetition": {
+            "current": "Repetir reunião: {{repetitionText}}",
+            "previous": "(previamente: {{repetitionText}})"
+          },
+          "title": {
+            "current": "Título: {{title}}",
+            "previous": "(previamente: {{title}})"
+          }
+        },
+        "closed": {
+          "message": "A sala foi fechada pelo administrador"
+        },
+        "noRepetition": "Sem repetição"
+      }
+    },
+    "user": {
+      "kicked": "Utilizador {{userId}} foi removido pelo {{sender}}"
+    }
+  },
+  "recurrenceEditor": {
+    "ordinals": {
+      "first": "primeiro",
+      "fourth": "quarto",
+      "last": "último",
+      "second": "segundo",
+      "third": "terceiro"
+    },
+    "ruleText": {
+      "afterMeetingCount_one": "uma vez",
+      "afterMeetingCount_other": "por {{count}} vezes",
+      "daily_one": "Todos os dias$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "daily_other": "Todos {{count}} dias$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_bymonthday_one": "Todos os meses em $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_bymonthday_other": "Todos {{count}} os meses em $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_byweekday_one": "Todos os meses em {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_byweekday_other": "Todos {{count}} os meses em {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_simple_one": "Todos os meses$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_simple_other": "Todos {{count}} meses$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "ordinal_ordinal_one": "{{count}}º",
+      "ordinal_ordinal_two": "{{count}}º",
+      "ordinal_ordinal_few": "{{count}}º",
+      "ordinal_ordinal_other": "{{count}}º",
+      "recurrenceEnd_count": "$t(recurrenceEditor.ruleText.afterMeetingCount, {\"count\": {{afterMeetingCount}}, \"ordinal\": false })",
+      "recurrenceEnd_never": "",
+      "recurrenceEnd_until": " até {{ untilDate, datetime(year: 'numeric'; month: 'long'; day: 'numeric') }}",
+      "unknown": "Recorrência não suportada",
+      "weekly_all_one": "Todas as semanas $t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_all_other": "Todas {{count}} as semanas $t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_some_one": "Todas as semanas em {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_some_other": "Todas {{count}} as semanas em {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_weekdays_one": "Todos os dias de semana$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_weekdays_other": "Todas {{count}} semanas nos os dias de semana$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_bymonthday_one": "Todos {{monthLabel}} em $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_bymonthday_other": "Todos {{count}} anos em $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true }) de {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_byweekday_one": "Todos {{monthLabel}} em {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_byweekday_other": "Todos {{count}} anos em {{ordinalLabel}} {{byweekday}} de {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_simple_one": "Todos os anos$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_simple_other": "Todos {{count}} anos$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })"
+    }
+  },
+  "welcome": {
+    "botIsAdmin": "O bot é um moderador na sala <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>. Se introduzir o comando <code>!meeting setup</code>, o widget NeoDateFix será adicionado à sala.",
+    "botNotAdmin": "O bot não é um moderador na sala <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.",
+    "errors": {
+      "meetingWidgetExists": "Impossível adicionar um novo widget porque já existe.",
+      "notEnoughPermissions": "Infelizmente, não consigo adicionar a funcionalidade do calendário. Não tenho a permissão necessária. Por favor dê-me direitos de moderador na sua sala <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>."
+    },
+    "helpWhenNotAdmin": "Infelizmente, não consigo adicionar a funcionalidade do calendário. Não tenho a permissão necessária. Por favor dê-me direitos de moderador na sua sala <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.",
+    "intro": [
+      "<p>Olá {{userDisplayName}}, obrigado por me convidar para <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.</p>",
+      "<p>Gostaria muito de o ajudar a colocar o calendário naquela sala.</p>",
+      "<p>Para que eu possa adicionar a função do calendário à sua sala, por favor dê-me a permissão necessária para adicionar widgets à sua sala <a href='{{originalRoomLink}}'>{{originalRoomName}}</a> (A função de moderador, por exemplo). Pode fazê-lo no meu perfil de utilizador que encontra no menu do lado direito através de \"info\"-icon.</p>",
+      "<p>Se não me quiser dar a autorização necessária, pode adicionar a funcionalidade do calendário à sua sala manualmente, enviando a seguinte mensagem para a sala: <code>/addwidget {{widgetURL}}</code></p>",
+      "<p>Para ter uma vista geral dos comandos pode enviar <code>!meeting help</code></p>"
+    ],
+    "introDone": [
+      "<p>Olá {{userDisplayName}}, obrigado por me convidar para <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.</p>",
+      "<p>A minha função foi ajudá-lo a instalar o calendário.</p>",
+      "<p>O calendário já foi instalado com sucesso na sua sala. Assim, já pode deixar esta caixa de chat.</p>",
+      "<p>Para ter uma vista geral dos comandos pode enviar <code>!meeting help</code></p>"
+    ],
+    "introLanguage": [
+      "Informação sobre as definições de idioma: Para possibilitar a comunicação na sua língua, pode usar os seguintes comandos: ",
+      "<ul>",
+      "<li>Mudar o idioma para Português: <code>!meeting lang pt</code></li>",
+      "<li>Mudar o idioma para Inglês: <code>!meeting lang en</code></li>",
+      "<li>Mudar o idioma para Francês: <code>!meeting lang fr</code></li>",
+      "<li>Mudar o idioma para Espanhol: <code>!meeting lang es</code></li>",
+      "<li>Mudar o idioma para Alemão: <code>!meeting lang de</code></li>",
+      "</ul>"
+    ],
+    "languageWasChanged": "O idioma foi alterado para <b>{{locale}}</b>.",
+    "meetingWidgetAdded": "<p>A minha função está cumprida.</p><p>O calendário já foi instalado na sua sala com sucesso. Já pode sair desta sala privada de chat.</p>",
+    "privateRoom": {
+      "inviteReason": "Nesta sala privada, o “bot” pode ajudar a adicionar um NeoDateFix widget à sala '{{originalRoomName}}'.",
+      "name": "Ajuda para {{originalRoomName}}",
+      "topic": "Como usar este “bot” para adicionar o widget bot na sala {{originalRoomName}}."
+    }
   }
-  
+}

--- a/matrix-meetings-bot/src/static/locales/pt/translation.json
+++ b/matrix-meetings-bot/src/static/locales/pt/translation.json
@@ -1,0 +1,159 @@
+{
+    "base": {
+      "exception": {
+        "message": "Um erro \"{{errorName}}\" ocorreu enquanto se processavam os eventos na sala {{roomId}} {{roomName}}. <br> Por favor forneça este número: [{{requestId}}] para mais questões."
+      }
+    },
+    "bot": {
+      "private": {
+        "errorRoom": {
+          "create": {
+            "message": "Mensagens de erro de NeoDateFix-Bot",
+            "topic": "Mais detalhes"
+          }
+        }
+      }
+    },
+    "commandErrors": {
+      "badCommand": "Comando incorreto, tente <code>{{trigger}} help</code>",
+      "badLanguageCode": "A linguagem de código não é suportada",
+      "generic": "Ocorreu um erro ao processar o seu comando: {{message}}",
+      "noCommandProvided": "Nenhum comando fornecido, tente <code>{{trigger}} help</code>",
+      "noLanguageCode": "A linguagem de código não é fornecida, use uma das seguintes ({{availableLanguageCodes}})"
+    },
+    "commandHelp": [
+      "<p>Comandos disponíveis:</p>",
+      "<ul>",
+      "<li><code>!meeting lang &lt;pt|en|fr|es|de&gt;</code> (Mude o idioma do bot nesta sala.)</li>",
+      "<li><code>!meeting setup</code> (Adiciona o calendário à sala.)</li>",
+      "<li><code>!meeting status</code> (Verifica a capacidade de adicionar o calendário.)</li>",
+      "</ul>"
+    ],
+    "meeting": {
+      "invite": {
+        "message": "📅 {{range, daterange}}<br/>$t(meeting.invite.messageRecurrence, {\"context\": \"{{recurrenceContext}}\" })<br/>$t(meeting.invite.messageByOrganizer, {\"context\": \"{{organizerContext}}\" })$t(meeting.invite.messageDescription, {\"context\": \"{{descriptionContext}}\" })",
+        "messageByOrganizer_none": "",
+        "messageByOrganizer_present": "\nverifica a capacidade de adicionar o calendário {{organizerDisplayName}}",
+        "messageDescription_none": "",
+        "messageDescription_present": "\n<hr><i>{{description}}</i>",
+        "messageRecurrence_none": "",
+        "messageRecurrence_present": "\n🔁 Recorrência: {{recurrence}}<br/>"
+      },
+      "room": {
+        "notification": {
+          "changed": {
+            "date": {
+              "current": "Data: {{range, daterange}}",
+              "previous": "(previamente: {{range, daterange}})"
+            },
+            "description": {
+              "current": "Descrição: {{description}}",
+              "previous": "(previamente: {{description}})"
+            },
+            "headLine": "ALTERAÇÕES",
+            "occurrence": {
+              "current": "Uma só reunião de uma série de reuniões é mudada para {{range, daterange}}",
+              "deleted": "Uma só reunião de uma série de reuniões é {{range, daterange}} apagada",
+              "previous": "(previamente: {{value, daterange}})"
+            },
+            "repetition": {
+              "current": "Repetir reunião: {{repetitionText}}",
+              "previous": "(previamente: {{repetitionText}})"
+            },
+            "title": {
+              "current": "Título: {{title}}",
+              "previous": "(previamente: {{title}})"
+            }
+          },
+          "closed": {
+            "message": "A sala foi fechada pelo administrador"
+          },
+          "noRepetition": "Sem repetição"
+        }
+      },
+      "user": {
+        "kicked": "Utilizador {{userId}} foi removido pelo {{sender}}"
+      }
+    },
+    "recurrenceEditor": {
+      "ordinals": {
+        "first": "primeiro",
+        "fourth": "quarto",
+        "last": "último",
+        "second": "segundo",
+        "third": "terceiro"
+      },
+      "ruleText": {
+        "afterMeetingCount_one": "uma vez",
+        "afterMeetingCount_other": "por {{count}} vezes",
+        "daily_one": "Todos os dias$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "daily_other": "Todos {{count}} dias$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_bymonthday_one": "Todos os meses em $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_bymonthday_other": "Todos {{count}} os meses em $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_byweekday_one": "Todos os meses em {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_byweekday_other": "Todos {{count}} os meses em {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_simple_one": "Todos os meses$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_simple_other": "Todos {{count}} meses$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "ordinal_ordinal_one": "{{count}}º",
+        "ordinal_ordinal_two": "{{count}}º",
+        "ordinal_ordinal_few": "{{count}}º",
+        "ordinal_ordinal_other": "{{count}}º",
+        "recurrenceEnd_count": "$t(recurrenceEditor.ruleText.afterMeetingCount, {\"count\": {{afterMeetingCount}}, \"ordinal\": false })",
+        "recurrenceEnd_never": "",
+        "recurrenceEnd_until": " até {{ untilDate, datetime(year: 'numeric'; month: 'long'; day: 'numeric') }}",
+        "unknown": "Recorrência não suportada",
+        "weekly_all_one": "Todas as semanas $t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "weekly_all_other": "Todas {{count}} as semanas $t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "weekly_some_one": "Todas as semanas em {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "weekly_some_other": "Todas {{count}} as semanas em {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "weekly_weekdays_one": "Todos os dias de semana$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "weekly_weekdays_other": "Todas {{count}} semanas nos os dias de semana$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_bymonthday_one": "Todos {{monthLabel}} em $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_bymonthday_other": "Todos {{count}} anos em $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true }) de {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_byweekday_one": "Todos {{monthLabel}} em {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_byweekday_other": "Todos {{count}} anos em {{ordinalLabel}} {{byweekday}} de {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_simple_one": "Todos os anos$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_simple_other": "Todos {{count}} anos$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })"
+      }
+    },
+    "welcome": {
+      "botIsAdmin": "O bot é um moderador na sala <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>. Se introduzir o comando <code>!meeting setup</code>, o widget NeoDateFix será adicionado à sala.",
+      "botNotAdmin": "O bot não é um moderador na sala <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.",
+      "errors": {
+        "meetingWidgetExists": "Impossível adicionar um novo widget porque já existe.",
+        "notEnoughPermissions": "Infelizmente, não consigo adicionar a funcionalidade do calendário. Não tenho a permissão necessária. Por favor dê-me direitos de moderador na sua sala <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>."
+      },
+      "helpWhenNotAdmin": "Infelizmente, não consigo adicionar a funcionalidade do calendário. Não tenho a permissão necessária. Por favor dê-me direitos de moderador na sua sala <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.",
+      "intro": [
+        "<p>Olá {{userDisplayName}}, obrigado por me convidar para <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.</p>",
+        "<p>Gostaria muito de o ajudar a colocar o calendário naquela sala.</p>",
+        "<p>Para que eu possa adicionar a função do calendário à sua sala, por favor dê-me a permissão necessária para adicionar widgets à sua sala <a href='{{originalRoomLink}}'>{{originalRoomName}}</a> (A função de moderador, por exemplo). Pode fazê-lo no meu perfil de utilizador que encontra no menu do lado direito através de \"info\"-icon.</p>",
+        "<p>Se não me quiser dar a autorização necessária, pode adicionar a funcionalidade do calendário à sua sala manualmente, enviando a seguinte mensagem para a sala: <code>/addwidget {{widgetURL}}</code></p>",
+        "<p>Para ter uma vista geral dos comandos pode enviar <code>!meeting help</code></p>"
+      ],
+      "introDone": [
+        "<p>Olá {{userDisplayName}}, obrigado por me convidar para <a href='{{originalRoomLink}}'>{{originalRoomName}}</a>.</p>",
+        "<p>A minha função foi ajudá-lo a instalar o calendário.</p>",
+        "<p>O calendário já foi instalado com sucesso na sua sala. Assim, já pode deixar esta caixa de chat.</p>",
+        "<p>Para ter uma vista geral dos comandos pode enviar <code>!meeting help</code></p>"
+      ],
+      "introLanguage": [
+        "Informação sobre as definições de idioma: Para possibilitar a comunicação na sua língua, pode usar os seguintes comandos: ",
+        "<ul>",
+        "<li>Mudar o idioma para Português: <code>!meeting lang pt</code></li>",
+        "<li>Mudar o idioma para Inglês: <code>!meeting lang en</code></li>",
+        "<li>Mudar o idioma para Francês: <code>!meeting lang fr</code></li>",
+        "<li>Mudar o idioma para Espanhol: <code>!meeting lang es</code></li>",
+        "<li>Mudar o idioma para Alemão: <code>!meeting lang de</code></li>",
+        "</ul>"
+      ],
+      "languageWasChanged": "O idioma foi alterado para <b>{{locale}}</b>.",
+      "meetingWidgetAdded": "<p>A minha função está cumprida.</p><p>O calendário já foi instalado na sua sala com sucesso. Já pode sair desta sala privada de chat.</p>",
+      "privateRoom": {
+        "inviteReason": "Nesta sala privada, o “bot” pode ajudar a adicionar um NeoDateFix widget à sala '{{originalRoomName}}'.",
+        "name": "Ajuda para {{originalRoomName}}",
+        "topic": "Como usar este “bot” para adicionar o widget bot na sala {{originalRoomName}}."
+      }
+    }
+  }
+  

--- a/matrix-meetings-widget/public/locales/en/translation.json
+++ b/matrix-meetings-widget/public/locales/en/translation.json
@@ -166,7 +166,7 @@
     }
   },
   "meetingHasBreakoutSessionsWarning": {
-    "message": "If you want to change start or end time of this meeting, existing breakout sessions will not be moved!",
+    "message": "If you want to change start or end the time of this meeting, existing breakout sessions will not be moved!",
     "title": "The meeting already has breakout sessions."
   },
   "meetingInvitationGuard": {
@@ -174,8 +174,8 @@
   },
   "meetingList": {
     "groupTitle": "{{date, datetime}}",
-    "noBreakoutSessionsScheduled": "No breakout sessions scheduled that match the selected filters.",
-    "noMeetingsScheduled": "No meetings scheduled that match the selected filters.",
+    "noBreakoutSessionsScheduled": "There are no breakout sessions scheduled that match the selected filters.",
+    "noMeetingsScheduled": "There are no meetings scheduled that match the selected filters.",
     "openInvitationsDetail": "Please join all meeting rooms.",
     "openInvitationsTitle": "You have open invitations.",
     "title": "Meetings"
@@ -285,7 +285,7 @@
         "byMonthday": "On day",
         "byMonthdayLong": "The meeting is repeated yearly on {{nthMonthday}} {{month}}",
         "byWeekday": "On the",
-        "byWeekdayLong": "The meeting is repeated yearly at {{ordinalLabel}} {{weekday}} of {{month}}",
+        "byWeekdayLong": "The meeting is repeated yearly on {{ordinalLabel}} {{weekday}} of {{month}}",
         "byWeekdayOf": "of",
         "customRuleMode": "Custom Rule",
         "invalidInput": "Invalid input",
@@ -321,7 +321,7 @@
       "never": "Never",
       "neverLong": "The meeting is repeated forever",
       "untilDate": "On",
-      "untilDateInput": "Date at which the recurring meetings ends",
+      "untilDateInput": "Date at which the recurring meeting ends",
       "untilDateInputInvalid": "Invalid date",
       "untilDateInputOpenDatePicker": "Choose date at which the recurring meeting ends, selected date is {{date, datetime}}",
       "untilDateLong": "The meeting is repeated till {{date,datetime}}"
@@ -333,7 +333,7 @@
       "daily_one": "Every day$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
       "daily_other": "Every {{count}} days$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
       "monthly_bymonthday_one": "Every month on the $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-      "monthly_bymonthday_other": "Every {{count}} months on the $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_bymonthday_other": "Every {{count}} month on the $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
       "monthly_byweekday_one": "Every month on the {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
       "monthly_byweekday_other": "Every {{count}} months on the {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
       "monthly_simple_one": "Every month$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
@@ -349,13 +349,13 @@
       "weekly_all_one": "Every week$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
       "weekly_all_other": "Every {{count}} weeks$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
       "weekly_some_one": "Every week on {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-      "weekly_some_other": "Every {{count}} weeks on {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_some_other": "Every {{count}} week on {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
       "weekly_weekdays_one": "Every weekday$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-      "weekly_weekdays_other": "Every {{count}} weeks on weekdays$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_weekdays_other": "Every {{count}} week on weekdays$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
       "yearly_bymonthday_one": "Every {{monthLabel}} on the $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-      "yearly_bymonthday_other": "Every {{count}} years on the $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true }) of {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_bymonthday_other": "Every {{count}} year on the $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true }) of {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
       "yearly_byweekday_one": "Every {{monthLabel}} on the {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-      "yearly_byweekday_other": "Every {{count}} years on the {{ordinalLabel}} {{byweekday}} of {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_byweekday_other": "Every {{count}} year on the {{ordinalLabel}} {{byweekday}} of {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
       "yearly_simple_one": "Every year$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
       "yearly_simple_other": "Every {{count}} years$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })"
     },
@@ -388,7 +388,7 @@
     "groupNumberErrorMessage": "There are not enough participants for the number of groups you have entered.",
     "groups": "Groups",
     "groupTitleDefaultValue": "Group {{index}}",
-    "meetingIsOver": "The meeting is over you can not create any new breakout sessions.",
+    "meetingIsOver": "The meeting is over so you can not create any new breakout sessions.",
     "notAssignedMessage": "Some participants are not assigned to a group.",
     "notAssignedTitle": "Note",
     "startAt": "Start at"

--- a/matrix-meetings-widget/public/locales/en/translation.json
+++ b/matrix-meetings-widget/public/locales/en/translation.json
@@ -166,7 +166,7 @@
     }
   },
   "meetingHasBreakoutSessionsWarning": {
-    "message": "If you want to change start or end the time of this meeting, existing breakout sessions will not be moved!",
+    "message": "If you want to change start or end time of this meeting, existing breakout sessions will not be moved!",
     "title": "The meeting already has breakout sessions."
   },
   "meetingInvitationGuard": {
@@ -174,8 +174,8 @@
   },
   "meetingList": {
     "groupTitle": "{{date, datetime}}",
-    "noBreakoutSessionsScheduled": "There are no breakout sessions scheduled that match the selected filters.",
-    "noMeetingsScheduled": "There are no meetings scheduled that match the selected filters.",
+    "noBreakoutSessionsScheduled": "No breakout sessions scheduled that match the selected filters.",
+    "noMeetingsScheduled": "No meetings scheduled that match the selected filters.",
     "openInvitationsDetail": "Please join all meeting rooms.",
     "openInvitationsTitle": "You have open invitations.",
     "title": "Meetings"
@@ -285,7 +285,7 @@
         "byMonthday": "On day",
         "byMonthdayLong": "The meeting is repeated yearly on {{nthMonthday}} {{month}}",
         "byWeekday": "On the",
-        "byWeekdayLong": "The meeting is repeated yearly on {{ordinalLabel}} {{weekday}} of {{month}}",
+        "byWeekdayLong": "The meeting is repeated yearly at {{ordinalLabel}} {{weekday}} of {{month}}",
         "byWeekdayOf": "of",
         "customRuleMode": "Custom Rule",
         "invalidInput": "Invalid input",
@@ -321,7 +321,7 @@
       "never": "Never",
       "neverLong": "The meeting is repeated forever",
       "untilDate": "On",
-      "untilDateInput": "Date at which the recurring meeting ends",
+      "untilDateInput": "Date at which the recurring meetings ends",
       "untilDateInputInvalid": "Invalid date",
       "untilDateInputOpenDatePicker": "Choose date at which the recurring meeting ends, selected date is {{date, datetime}}",
       "untilDateLong": "The meeting is repeated till {{date,datetime}}"
@@ -388,7 +388,7 @@
     "groupNumberErrorMessage": "There are not enough participants for the number of groups you have entered.",
     "groups": "Groups",
     "groupTitleDefaultValue": "Group {{index}}",
-    "meetingIsOver": "The meeting is over so you can not create any new breakout sessions.",
+    "meetingIsOver": "The meeting is over you can not create any new breakout sessions.",
     "notAssignedMessage": "Some participants are not assigned to a group.",
     "notAssignedTitle": "Note",
     "startAt": "Start at"

--- a/matrix-meetings-widget/public/locales/es/translation.json
+++ b/matrix-meetings-widget/public/locales/es/translation.json
@@ -1,418 +1,417 @@
 {
-    "breakoutSessionGroup": {
-      "groupTitle": "Nombre del grupo (obligatorio)",
-      "groupTitleHelperText": "Es obligatorio un nombre para el grupo",
-      "selectUser": "Seleccione participantes",
-      "youAreAlwaysMember": "El organizador tiene acceso a todas las sesiones de breakout."
+  "breakoutSessionGroup": {
+    "groupTitle": "Nombre del grupo (obligatorio)",
+    "groupTitleHelperText": "Es obligatorio un nombre para el grupo",
+    "selectUser": "Seleccione participantes",
+    "youAreAlwaysMember": "El organizador tiene acceso a todas las sesiones de breakout."
+  },
+  "calendarDayPicker": {
+    "chooseDate": "Seleccione la fecha, la fecha seleccionada es {{date, datetime}}",
+    "label": "{{date, datetime}}"
+  },
+  "calendarMonthPicker": {
+    "chooseMonth": "Seleccione el mes, el mes seleccionado es {{date, datetime}}",
+    "label": "{{date, datetime}}"
+  },
+  "calendarWeekPicker": {
+    "chooseWeek": "Seleccione la semana, la semana seleccionada es {{range, daterange}}",
+    "label": "{{range, daterange}}"
+  },
+  "calendarWorkWeekPicker": {
+    "chooseWorkWeek": "Seleccione la semana de trabajo, la semana de trabajo seleccionada es {{range, daterange}}",
+    "label": "{{range, daterange}}"
+  },
+  "cancel": "Cancelar",
+  "close": "Cerrar",
+  "cockpitPanel": {
+    "toParentRoom": "Volver a la sesión de padres"
+  },
+  "copyableTextButton": {
+    "copy-to-clipboard": "Copiar para la carpeta de descargas"
+  },
+  "dateRangePicker": {
+    "chooseDate": "Seleccione el intervalo de fechas, el intervalo seleccionado es {{range, daterange}}",
+    "dateRange": "{{range, daterange}}"
+  },
+  "dateTimePickers": {
+    "endDate": "Fecha de finalización",
+    "endTime": "Hora de finalización",
+    "error": {
+      "breakoutSessionInvalidEndTime": "Las sesiones de breakout tienen que terminar entre {{minDate, datetime}} y {{maxDate, datetime}}.",
+      "breakoutSessionInvalidStartTime": "Las sesiones de breakout tienen que comenzar entre {{minDate, datetime}} y {{maxDate, datetime}}.",
+      "breakoutSessionStartBeforeEnd": "La sesión de grupo debe comenzar antes de que termine.",
+      "meetingStartBeforeEnd": "La reunión debe comenzar antes de que termine.",
+      "meetingStartTooEarly": "La reunión no puede comenzar en el pasado."
     },
-    "calendarDayPicker": {
-      "chooseDate": "Seleccione la fecha, la fecha seleccionada es {{date, datetime}}",
-      "label": "{{date, datetime}}"
-    },
-    "calendarMonthPicker": {
-      "chooseMonth": "Seleccione el mes, el mes seleccionado es {{date, datetime}}",
-      "label": "{{date, datetime}}"
-    },
-    "calendarWeekPicker": {
-      "chooseWeek": "Seleccione la semana, la semana seleccionada es {{range, daterange}}",
-      "label": "{{range, daterange}}"
-    },
-    "calendarWorkWeekPicker": {
-      "chooseWorkWeek": "Seleccione la semana de trabajo, la semana de trabajo seleccionada es {{range, daterange}}",
-      "label": "{{range, daterange}}"
-    },
+    "invalidEndDate": "Fecha incorrecta",
+    "invalidEndTime": "Hora incorrecta",
+    "invalidStartDate": "Fecha incorrecta",
+    "invalidStartTime": "Hora incorrecta",
+    "openEndDatePicker": "Seleccione la fecha de finalización, la fecha seleccionada es {{date, datetime}}",
+    "openEndTimePicker": "Seleccione la hora de finalización, la hora seleccionada es {{date, datetime}}",
+    "openStartDatePicker": "Seleccione la fecha de inicio, la fecha seleccionada es {{date, datetime}}",
+    "openStartTimePicker": "Seleccione la hora de inicio, la hora seleccionada es {{date, datetime}}",
+    "startDate": "Fecha de inicio",
+    "startTime": "Hora de inicio"
+  },
+  "editMeetingModal": {
     "cancel": "Cancelar",
-    "close": "Cerrar",
-    "cockpitPanel": {
-      "toParentRoom": "Volver a la sesión de padres"
-    },
-    "copyableTextButton": {
-      "copy-to-clipboard": "Copiar para la carpeta de descargas"
-    },
-    "dateRangePicker": {
-      "chooseDate": "Seleccione el intervalo de fechas, el intervalo seleccionado es {{range, daterange}}",
-      "dateRange": "{{range, daterange}}"
-    },
-    "dateTimePickers": {
-      "endDate": "Fecha de finalización",
-      "endTime": "Hora de finalización",
-      "error": {
-        "breakoutSessionInvalidEndTime": "Las sesiones de breakout tienen que terminar entre {{minDate, datetime}} y {{maxDate, datetime}}.",
-        "breakoutSessionInvalidStartTime": "Las sesiones de breakout tienen que comenzar entre {{minDate, datetime}} y {{maxDate, datetime}}.",
-        "breakoutSessionStartBeforeEnd": "La sesión de grupo debe comenzar antes de que termine.",
-        "meetingStartBeforeEnd": "La reunión debe comenzar antes de que termine.",
-        "meetingStartTooEarly": "La reunión no puede comenzar en el pasado."
-      },
-      "invalidEndDate": "Fecha incorrecta",
-      "invalidEndTime": "Hora incorrecta",
-      "invalidStartDate": "Fecha incorrecta",
-      "invalidStartTime": "Hora incorrecta",
-      "openEndDatePicker": "Seleccione la fecha de finalización, la fecha seleccionada es {{date, datetime}}",
-      "openEndTimePicker": "Seleccione la hora de finalización, la hora seleccionada es {{date, datetime}}",
-      "openStartDatePicker": "Seleccione la fecha de inicio, la fecha seleccionada es {{date, datetime}}",
-      "openStartTimePicker": "Seleccione la hora de inicio, la hora seleccionada es {{date, datetime}}",
-      "startDate": "Fecha de inicio",
-      "startTime": "Hora de inicio"
-    },
-    "editMeetingModal": {
-      "cancel": "Cancelar",
-      "save": "Guardar",
-      "title": "Modificar reunión"
-    },
-    "editRecurringMessage": {
-      "message": "Todas las instancias de la reunión periódica son editables",
-      "titleOne": "Modificar las reuniones periódicas"
-    },
-    "invitedMeetingList": {
-      "detail": {
-        "invitedBy": "Invitado por: {{name}}"
-      }
-    },
-    "invitedMeetingsList": {
-      "title": "Invitaciones"
-    },
-    "meetingCard": {
-      "actions": "Acciones",
-      "deleteInOpenXchangeMenu": "Eliminar reunión en Open-Xchange",
-      "deleteMenu": "Eliminar reunión",
-      "durationSubheader_default": "{{startDate, datetime}} – {{endDate, datetime}}",
-      "durationSubheader_recurring": "$t(meetingCard.durationSubheader_default)<0>. Reaparición: {{recurrence}}</0>",
-      "editInOpenXchangeMenu": "Modificar reunión en Open-Xchange",
-      "editMenu": "Modificar reunión",
-      "editParticipants": {
-        "buttonTitle": "Mostrar participantes",
-        "membership_invite": "Invitado",
-        "membership_join": "Aceptado",
-        "menuTitle": "Participantes"
-      },
-      "meetingRoomWillBeDeleted": "a sala de reunión se eliminará automáticamente {{remainingTime, relativetime}}.",
-      "meetingRoomWillBeDeletedSoon": "La sala de reunión se eliminará automáticamente pronto.",
-      "moreSettings": "Otras configuraciones",
-      "recurrenceTooltip": "Reaparición: {{recurrence}}",
-      "share": {
-        "buttonTitle": "Compartir reunión",
-        "dialInCopyNumber": "Número de acceso",
-        "dialInCopyPin": "Código de acceso",
-        "dialInDescription": "Utilice la siguiente información para acceder a la conferencia usando su teléfono móvil:",
-        "dialInTitle": "Invitar a otras personas",
-        "downloadIcsFile": "Descargar archivos ICS",
-        "emailCopyMessage": "Mensaje",
-        "emailDescription": "Utilice la siguiente información para compartir la conferencia, por ejemplo, por correo electrónico:",
-        "emailTitle": "Compartir la invitación para la reunión",
-        "icsDescription": "Descargar la reunión en formato iCalendar y agregar a la aplicación del calendário:",
-        "icsTitle": "Descargar el archivo de calendario",
-        "linkCopyMeetingLink": "Enlace para la reunión",
-        "linkDescription": "Usa el siguiente enlace para aceder a la reunión:",
-        "linkTitle": "Comparte el enlace para la sala de reunión",
-        "menuTitle": "Compartir reunión",
-        "message": "{{title}}\n\n📅 {{date, daterange}}\n$t(meetingCard.share.messageRecurrence, {\"context\": \"{{recurrenceContext}}\" })\n$t(meetingCard.share.messageDescription, {\"context\": \"{{descriptionContext}}\" })\n__________________________\nRoom: {{link}}\n$t(meetingCard.share.messageDialIn, {\"context\": \"{{dialInContext}}\" })",
-        "messageDescription_none": "",
-        "messageDescription_present": "{{description}}\n",
-        "messageDialIn_none": "",
-        "messageDialIn_nopin": "Número de acceso: {{dialInNumber}}\nDial-In Pin: Pin not required\n",
-        "messageDialIn_pin": "Número de acceso: {{dialInNumber}}\nDial-In Pin: {{dialInPin}}\n",
-        "messageRecurrence_none": "",
-        "messageRecurrence_present": "🔁 Reaparición: {{recurrence}}\n",
-        "shareByMail": "Compartir por correo electrónico",
-        "shareDialInNumber": "Compartir número de acceso",
-        "shareDialInNumberError": "Error al cargar la información de acceso.",
-        "shareDialInNumberNotPresent": "No hay información de acceso disponible",
-        "shareLink": "Compartir el enlace para la reunión",
-        "warningRecurringMeetingDialInNumber": "Este es un número de acceso para el ciclo de reuniones. Al compartir este número de acceso, invitas a los usuarios a todas las reuniones siguientes.",
-        "warningRecurringMeetingEmail": "Este es un correo electrónico de invitación para el ciclo de reuniones. Al compartir este correo electrónico, invitas a los usuarios a todas las reuniones siguientes.",
-        "warningRecurringMeetingICalFile": "Este es un archivo iCal para el ciclo de reuniones. Al compartir este archivo, invitas a los usuarios a todas las reuniones siguientes.",
-        "warningRecurringMeetingLink": "Este es un enlace de acceso al ciclo de reuniones. Al compartir este enlace, invitas a los usuarios a todas las reuniones siguientes."
-      },
-      "updateFailed": "Por favor, inténtelo de nuevo",
-      "updateFailedClose": "Cerrar",
-      "updateFailedTitle": "No se pudo actualizar la reunión"
-    },
-    "meetingDetails": {
-      "content": {
-        "dateAndTime": "{{range, daterange}}",
-        "description": "Descripción",
-        "details": "Descripción",
-        "organizer": "Organizador",
-        "participants": "Participantes",
-        "shareMeeting": {
-          "download": "Descargar",
-          "downloadIcsFile": "Descargar el archivo ICS",
-          "emailCopyMessage": "Mensaje",
-          "emailDescription": "Utilice la siguiente información para compartir la conferencia, por ejemplo por correo electrónico:",
-          "emailTitle": "Compartir la invitación a la reunión",
-          "icsDescription": "Descargar la reunión en formato iCalendar y agregarla a la aplicación de calendario:",
-          "icsTitle": "Descargar un archivo del calendario",
-          "shareByMail": "Compartir por correo electrónico",
-          "title": "Compartir reunión",
-          "warningRecurringMeetingEmail": "Este es un correo electrónico de invitación para el ciclo de reuniones. Al compartir este correo electrónico, invitas a los usuarios a todas las reuniones siguientes.",
-          "warningRecurringMeetingICalFile": "Este es un archivo iCal para el ciclo de reuniones. Al compartir este archivo, invitas a los usuarios a todas las reuniones siguientes."
-        }
-      },
-      "header": {
-        "deleteConfirmButton": "Eliminar",
-        "deleteConfirmHeader": "Eliminar reunión",
-        "deleteConfirmMessage": "¿Está seguro de que desea eliminar la reunión “{{title}}” a las {{startTime, datetime}} y todo el contenido relacionado con ella?",
-        "deleteFailed": "Por favor, inténtelo de nuevo.",
-        "deleteFailedTitle": "No se pudo eliminar la reunión",
-        "deleteInOpenXchangeMenu": "Eliminar reunión en Open-Xchange",
-        "deleteMeetingConfirmButton": "Eliminar reunión",
-        "deleteMenu": "Eliminar",
-        "deleteSeriesConfirmButton": "Eliminar serie",
-        "deleteSeriesConfirmMessage": "¿Está seguro de que desea eliminar la reunión o el ciclo de reuniones “{{title}}” a las {{startTime, datetime}} y todo el contenido relacionado con ella?",
-        "editInOpenXchangeMenu": "Modificar reunión en Open-Xchange",
-        "editMenu": "Modificar",
-        "join": "Acceder",
-        "joinBreakout_breakout": "Acceder"
-      }
-    },
-    "meetingHasBreakoutSessionsWarning": {
-      "message": "Si desea cambiar la hora de inicio o finalización de esta reunión, las sesiones de breakout no se moverán!",
-      "title": "La reunión ya cuenta con sesiones de breakout."
-    },
-    "meetingInvitationGuard": {
-      "meetingInvitation": "Por favor, acepte la invitación a la reunión para ver todos los detalles."
-    },
-    "meetingList": {
-      "groupTitle": "{{date, datetime}}",
-      "noBreakoutSessionsScheduled": "No hay sesiones de breakout programadas que coincidan con los filtros seleccionados.",
-      "noMeetingsScheduled": "No hay reuniones de breakout programadas que coincidan con los filtros seleccionados.",
-      "openInvitationsDetail": "Por favor, acceda a todas las salas de reuniones.",
-      "openInvitationsTitle": "Hay invitaciones abiertas.",
-      "title": "Reuniones"
-    },
-    "meetingsCalendar": {
-      "event": {
-        "startTime": "{{startTime, datetime}}",
-        "summary_default": "{{startTime, datetime}}–{{endTime, datetime}}: “{{title}}” por {{creator}}",
-        "summary_recurring": "{{startTime, datetime}}–{{endTime, datetime}}: “{{title}}” por {{creator}}, reunión recurrente"
-      }
-    },
-    "meetingsFilter": {
-      "filterAriaLabel": "Buscar",
-      "filterPlaceholder": "Buscar..."
-    },
-    "meetingsNavigation": {
-      "increaseWidth": "Aumentar el ancho del widget",
-      "increaseWidthToShowMore": "Aumente el ancho del widget para permitir más vistas.",
-      "label": "Ver",
-      "views": {
-        "day": "Dia",
-        "list": "Lista",
-        "month": "Mes",
-        "week": "Semana",
-        "workWeek": "Semana laboral"
-      }
-    },
-    "meetingsPanel": {
-      "actionsTitle": "Acciones",
-      "filtersTitle": "Filtros",
-      "messageToAllBreakoutRoom": {
-        "placeholder": "Enviar un mensaje...",
-        "sendFailed": "Por favor inténtalo de nuevo.",
-        "sendFailedTitle": "No se pudo enviar el mensaje",
-        "sendLabel": "Enviar mensaje para todas las salas",
-        "sendTimeout": "El cambio se envió correctamente y se aplicará pronto.",
-        "sendTimeoutTitle": "El pedido ha sido enviado",
-        "title": "Enviar mensaje a todas las salas de sesiones de breakout"
-      },
-      "scheduleBreakoutSession": "Programar una sesión de breakout",
-      "scheduleMeeting": "Programar reunión",
-      "tabTitle": "Vistas",
-      "tabTitleInvitations": "Invitaciones",
-      "tabTitleMeetings": "Reuniones"
-    },
-    "meetingsToolbar": {
-      "filterAriaLabel": "Buscar",
-      "filterPlaceholder": "Buscar...",
-      "next": {
-        "day": "Día siguiente",
-        "month": "Mes siguiente",
-        "period": "Período siguiente",
-        "week": "Semana siguiente",
-        "workweek": "Próxima semana laboral"
-      },
-      "previous": {
-        "day": "Día anterior",
-        "month": "Mes anterior",
-        "period": "Período anterior",
-        "week": "Semana anterior",
-        "workweek": "Semana laboral anterior"
-      },
-      "today": "Hoy"
-    },
-    "meetingViewEditMeeting": {
-      "breakoutSessionIsOver": "La sesión de breakout ha finalizado y no se puede cambiar.",
-      "meetingIsOver": "La reunión ha finalizado y no se puede cambiar."
-    },
-    "memberSelectionDropdown": {
-      "instructions_one": "{{selectedCount}} de {{count}} entrada seleccionada. Use las teclas de flecha izquierda y derecha para navegar entre ellas. Use las teclas de flecha arriba y abajo para acceder a las opciones disponibles.",
-      "instructions_other": "{{selectedCount}} de {{count}} entrada seleccionada. Use las teclas de flecha izquierda y derecha para navegar entre ellas. Use las teclas de flecha arriba y abajo para acceder a las opciones disponibles.",
-      "loadingError": "No se pudo cargar los usuários disponibles.",
-      "loadingUsers": "Cargando usuarios...",
-      "noMembers": "No hay membros disponibles.",
-      "tagInstructions": "Use la tecla de retroceso para eliminar la entrada."
-    },
-    "openMeetingRoomButton": {
-      "openMeetingRoom": "Abrir sala de reunión",
-      "openMeetingRoom_breakout": "Abrir sala de sesiones de breakout"
-    },
-    "recurrenceEditor": {
-      "custom": {
-        "frequency": {
-          "days": "Días",
-          "months": "Meses",
-          "weeks": "Semanas",
-          "years": "Años"
-        },
-        "frequencyLabel": "Repetir",
-        "intervalLabel": "{{frequencyLabel}} hasta que se repita la reunión",
-        "invalidInput": "Entrada no válida",
-        "monthly": {
-          "byMonthday": "En el día",
-          "byMonthdayLong": "a reunión se repetirá mensualmente en {{nthMonthday}}",
-          "byWeekday": "En",
-          "byWeekdayLong": "La reunión se repetirá mensualmente en {{ordinalLabel}} {{weekday}}",
-          "customRuleMode": "Regla personalizada",
-          "invalidInput": "Entrada no válida",
-          "monthdayInput": "Día"
-        },
-        "repeatEvery": "Repetir cada",
-        "title": "Reunión periódica personalizada",
-        "weekly": {
-          "repeatOnWeekday": "Repetir en el día de la semana"
-        },
-        "yearly": {
-          "byMonthday": "En el día",
-          "byMonthdayLong": "La reunión se repetirá anualmente en {{nthMonthday}} {{month}}",
-          "byWeekday": "En",
-          "byWeekdayLong": "La reunión se repetirá anualmente en {{ordinalLabel}} {{weekday}} of {{month}}",
-          "byWeekdayOf": "de",
-          "customRuleMode": "Regla personalizada",
-          "invalidInput": "Entrada no válida",
-          "monthdayInput": "Día"
-        }
-      },
-      "monthLabel": "Mes",
-      "ordinalLabel": "Ordinal",
-      "ordinals": {
-        "first": "primero",
-        "fourth": "cuarto",
-        "last": "último",
-        "second": "segundo",
-        "third": "tercero"
-      },
-      "recurrencePreset": {
-        "custom": "Personalizado",
-        "daily": "A diario",
-        "mondayToFriday": "De lunes a viernes",
-        "monthly": "Mensualmente",
-        "once": "Sin repetición",
-        "weekly": "Semanalmente",
-        "yearly": "Anualmente"
-      },
-      "recurringMeetingEnd": {
-        "afterMeetingCount": "Después",
-        "afterMeetingCountInput": "Recuento de reuniones",
-        "afterMeetingCountInputUnit": "Reuniones",
-        "afterMeetingCountLong_one": "Termina después de {{count}} reuniones",
-        "afterMeetingCountLong_other": "Termina después de {{count}} reuniones",
-        "endOfRecurringMeeting": "Fin de la reunión periódica",
-        "invalidInput": "Entrada no válida",
-        "never": "Nunca",
-        "neverLong": "La reunión se repetirá para siempre",
-        "untilDate": "En",
-        "untilDateInput": "Fecha de finalización de la reunión periódica",
-        "untilDateInputInvalid": "Fecha no válida",
-        "untilDateInputOpenDatePicker": "Seleccione la fecha en que finaliza la reunión periódica, la fecha seleccionada {{date, datetime}}",
-        "untilDateLong": "La reunión se repetirá hasta {{date,datetime}}"
-      },
-      "repeatMeeting": "Repetir reunión",
-      "ruleText": {
-        "afterMeetingCount_one": "Una vez",
-        "afterMeetingCount_other": "por {{count}} vezes",
-        "daily_one": "Todos day$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "daily_other": "Todos {{count}} days$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_bymonthday_one": "Todos los $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_bymonthday_other": "Cada {{count}} meses, en $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_byweekday_one": "Mensualmente, en {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_byweekday_other": "Cada {{count}} meses, en {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_simple_one": "Todos los  month$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_simple_other": "Cada {{count}} months$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "ordinal_ordinal_one": "{{count}}º",
-        "ordinal_ordinal_two": "{{count}}º",
-        "ordinal_ordinal_few": "{{count}}º",
-        "ordinal_ordinal_other": "{{count}}º",
-        "recurrenceEnd_count": " $t(recurrenceEditor.ruleText.afterMeetingCount, {\"count\": {{afterMeetingCount}}, \"ordinal\": false })",
-        "recurrenceEnd_never": "",
-        "recurrenceEnd_until": " hasta {{ untilDate, datetime(year: 'numeric'; month: 'long'; day: 'numeric') }}",
-        "unknown": "Recurrencia no admitida",
-        "weekly_all_one": "Todos los week$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "weekly_all_other": "Todos los {{count}} weeks$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "weekly_some_one": "Semanalmente, en {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "weekly_some_other": "Cada {{count}} semanas, en {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "weekly_weekdays_one": "Todos los weekday$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "weekly_weekdays_other": "Cada {{count}} semanas, en weekdays$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_bymonthday_one": "Todos los {{monthLabel}} en $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_bymonthday_other": "Todos los {{count}} años, en $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true }) of {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_byweekday_one": "Todos los {{monthLabel}} en {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_byweekday_other": "Cada {{count}} años, en {{ordinalLabel}} {{byweekday}} of {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_simple_one": "EvTodos losery year$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_simple_other": "Todos los {{count}} years$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })"
-      },
-      "weekdayLabel": "Semanalmente"
-    },
-    "scheduleMeeting": {
-      "allowMessaging": "Permitir enviar mensajes a todos los participantes",
-      "cannotRemoveOwnUser": "No puede eliminar su usuario de la runión.",
-      "description": "Descripción",
-      "endAt": "Finaliza en",
-      "hasPowerToKickUser": "No tiene permiso para eliminar a este participante.",
-      "meetingAlreadyStarted": "La reunión ya ha comenzado.",
-      "participants": "Participantes",
-      "startAt": "Comienza en",
-      "title": "Título (obligatorio)",
-      "titleHelperText": "Es obligatorio un título",
-      "typeToSearch": "Escriba para buscar un usuario...",
-      "youAreAlwaysMember": "El organizador accederá siempre a la reunión."
-    },
-    "scheduleMeetingModal": {
-      "cancel": "Cancelar",
-      "create": "Crear reunión",
-      "scheduleTitle": "Programar reunión"
-    },
-    "setupBreakoutSessions": {
-      "description": "Descripción",
-      "distributeAllRoomMembers": "Distribuir todos los {{amount}} participants",
-      "endAt": "Finaliza en",
-      "groupNumber": "Número de grupo (obligatorio)",
-      "groupNumberErrorMessage": "No hay participantes suficientes para el número de grupos que has introducido.",
-      "groups": "Grupos",
-      "groupTitleDefaultValue": "Grupo {{index}}",
-      "meetingIsOver": "La reunión há finalizado y no puede crear sesiones de breakout.",
-      "notAssignedMessage": "Algunos participantes no están asignados a un grupo.",
-      "notAssignedTitle": "Observación",
-      "startAt": "Comienza en"
-    },
-    "setupBreakoutSessionsModal": {
-      "cancel": "Cancelar",
-      "create": "Crear una sesión de breakout",
-      "title": "Programar una sesión de breakout"
-    },
-    "timeDistance": {
-      "futureText": "{{duration, relativetime}}",
-      "futureTextExact": "en {{duration}}",
-      "remainingText": "Finaliza {{duration, relativetime}}",
-      "remainingTextExact": "Finaliza en {{duration}}"
-    },
-    "widgetSelectionDropdown": {
-      "allActive": "Todos los widgets disponibles están activos.",
-      "instructions_one": "{{selectedCount}} de {{count}} entrada seleccionada. Use las teclas de flecha izquierda y derecha para navegar entre ellas. Use las teclas de flecha arriba y abajo para seleccionar opciones.",
-      "instructions_other": "{{selectedCount}} de {{count}} entrada seleccionada. Use las teclas de flecha izquierda y derecha para navegar entre ellas. Use las teclas de flecha arriba y abajo para seleccionar opciones.",
-      "label": "Widgets",
-      "loading": "Cargando widgets...",
-      "loadingError": "No se pudieron cargar los Widgets disponibles.",
-      "noWidgets": "No hay widgets disponibles.",
-      "tagInstructions": "Use la tecla de retroceso para eliminar la entrada."
+    "save": "Guardar",
+    "title": "Modificar reunión"
+  },
+  "editRecurringMessage": {
+    "message": "Todas las instancias de la reunión periódica son editables",
+    "titleOne": "Modificar las reuniones periódicas"
+  },
+  "invitedMeetingList": {
+    "detail": {
+      "invitedBy": "Invitado por: {{name}}"
     }
+  },
+  "invitedMeetingsList": {
+    "title": "Invitaciones"
+  },
+  "meetingCard": {
+    "actions": "Acciones",
+    "deleteInOpenXchangeMenu": "Eliminar reunión en Open-Xchange",
+    "deleteMenu": "Eliminar reunión",
+    "durationSubheader_default": "{{startDate, datetime}} – {{endDate, datetime}}",
+    "durationSubheader_recurring": "$t(meetingCard.durationSubheader_default)<0>. Reaparición: {{recurrence}}</0>",
+    "editInOpenXchangeMenu": "Modificar reunión en Open-Xchange",
+    "editMenu": "Modificar reunión",
+    "editParticipants": {
+      "buttonTitle": "Mostrar participantes",
+      "membership_invite": "Invitado",
+      "membership_join": "Aceptado",
+      "menuTitle": "Participantes"
+    },
+    "meetingRoomWillBeDeleted": "a sala de reunión se eliminará automáticamente {{remainingTime, relativetime}}.",
+    "meetingRoomWillBeDeletedSoon": "La sala de reunión se eliminará automáticamente pronto.",
+    "moreSettings": "Otras configuraciones",
+    "recurrenceTooltip": "Reaparición: {{recurrence}}",
+    "share": {
+      "buttonTitle": "Compartir reunión",
+      "dialInCopyNumber": "Número de acceso",
+      "dialInCopyPin": "Código de acceso",
+      "dialInDescription": "Utilice la siguiente información para acceder a la conferencia usando su teléfono móvil:",
+      "dialInTitle": "Invitar a otras personas",
+      "downloadIcsFile": "Descargar archivos ICS",
+      "emailCopyMessage": "Mensaje",
+      "emailDescription": "Utilice la siguiente información para compartir la conferencia, por ejemplo, por correo electrónico:",
+      "emailTitle": "Compartir la invitación para la reunión",
+      "icsDescription": "Descargar la reunión en formato iCalendar y agregar a la aplicación del calendário:",
+      "icsTitle": "Descargar el archivo de calendario",
+      "linkCopyMeetingLink": "Enlace para la reunión",
+      "linkDescription": "Usa el siguiente enlace para aceder a la reunión:",
+      "linkTitle": "Comparte el enlace para la sala de reunión",
+      "menuTitle": "Compartir reunión",
+      "message": "{{title}}\n\n📅 {{date, daterange}}\n$t(meetingCard.share.messageRecurrence, {\"context\": \"{{recurrenceContext}}\" })\n$t(meetingCard.share.messageDescription, {\"context\": \"{{descriptionContext}}\" })\n__________________________\nRoom: {{link}}\n$t(meetingCard.share.messageDialIn, {\"context\": \"{{dialInContext}}\" })",
+      "messageDescription_none": "",
+      "messageDescription_present": "{{description}}\n",
+      "messageDialIn_none": "",
+      "messageDialIn_nopin": "Número de acceso: {{dialInNumber}}\nDial-In Pin: Pin not required\n",
+      "messageDialIn_pin": "Número de acceso: {{dialInNumber}}\nDial-In Pin: {{dialInPin}}\n",
+      "messageRecurrence_none": "",
+      "messageRecurrence_present": "🔁 Reaparición: {{recurrence}}\n",
+      "shareByMail": "Compartir por correo electrónico",
+      "shareDialInNumber": "Compartir número de acceso",
+      "shareDialInNumberError": "Error al cargar la información de acceso.",
+      "shareDialInNumberNotPresent": "No hay información de acceso disponible",
+      "shareLink": "Compartir el enlace para la reunión",
+      "warningRecurringMeetingDialInNumber": "Este es un número de acceso para el ciclo de reuniones. Al compartir este número de acceso, invitas a los usuarios a todas las reuniones siguientes.",
+      "warningRecurringMeetingEmail": "Este es un correo electrónico de invitación para el ciclo de reuniones. Al compartir este correo electrónico, invitas a los usuarios a todas las reuniones siguientes.",
+      "warningRecurringMeetingICalFile": "Este es un archivo iCal para el ciclo de reuniones. Al compartir este archivo, invitas a los usuarios a todas las reuniones siguientes.",
+      "warningRecurringMeetingLink": "Este es un enlace de acceso al ciclo de reuniones. Al compartir este enlace, invitas a los usuarios a todas las reuniones siguientes."
+    },
+    "updateFailed": "Por favor, inténtelo de nuevo",
+    "updateFailedClose": "Cerrar",
+    "updateFailedTitle": "No se pudo actualizar la reunión"
+  },
+  "meetingDetails": {
+    "content": {
+      "dateAndTime": "{{range, daterange}}",
+      "description": "Descripción",
+      "details": "Descripción",
+      "organizer": "Organizador",
+      "participants": "Participantes",
+      "shareMeeting": {
+        "download": "Descargar",
+        "downloadIcsFile": "Descargar el archivo ICS",
+        "emailCopyMessage": "Mensaje",
+        "emailDescription": "Utilice la siguiente información para compartir la conferencia, por ejemplo por correo electrónico:",
+        "emailTitle": "Compartir la invitación a la reunión",
+        "icsDescription": "Descargar la reunión en formato iCalendar y agregarla a la aplicación de calendario:",
+        "icsTitle": "Descargar un archivo del calendario",
+        "shareByMail": "Compartir por correo electrónico",
+        "title": "Compartir reunión",
+        "warningRecurringMeetingEmail": "Este es un correo electrónico de invitación para el ciclo de reuniones. Al compartir este correo electrónico, invitas a los usuarios a todas las reuniones siguientes.",
+        "warningRecurringMeetingICalFile": "Este es un archivo iCal para el ciclo de reuniones. Al compartir este archivo, invitas a los usuarios a todas las reuniones siguientes."
+      }
+    },
+    "header": {
+      "deleteConfirmButton": "Eliminar",
+      "deleteConfirmHeader": "Eliminar reunión",
+      "deleteConfirmMessage": "¿Está seguro de que desea eliminar la reunión “{{title}}” a las {{startTime, datetime}} y todo el contenido relacionado con ella?",
+      "deleteFailed": "Por favor, inténtelo de nuevo.",
+      "deleteFailedTitle": "No se pudo eliminar la reunión",
+      "deleteInOpenXchangeMenu": "Eliminar reunión en Open-Xchange",
+      "deleteMeetingConfirmButton": "Eliminar reunión",
+      "deleteMenu": "Eliminar",
+      "deleteSeriesConfirmButton": "Eliminar serie",
+      "deleteSeriesConfirmMessage": "¿Está seguro de que desea eliminar la reunión o el ciclo de reuniones “{{title}}” a las {{startTime, datetime}} y todo el contenido relacionado con ella?",
+      "editInOpenXchangeMenu": "Modificar reunión en Open-Xchange",
+      "editMenu": "Modificar",
+      "join": "Acceder",
+      "joinBreakout_breakout": "Acceder"
+    }
+  },
+  "meetingHasBreakoutSessionsWarning": {
+    "message": "Si desea cambiar la hora de inicio o finalización de esta reunión, las sesiones de breakout no se moverán!",
+    "title": "La reunión ya cuenta con sesiones de breakout."
+  },
+  "meetingInvitationGuard": {
+    "meetingInvitation": "Por favor, acepte la invitación a la reunión para ver todos los detalles."
+  },
+  "meetingList": {
+    "groupTitle": "{{date, datetime}}",
+    "noBreakoutSessionsScheduled": "No hay sesiones de breakout programadas que coincidan con los filtros seleccionados.",
+    "noMeetingsScheduled": "No hay reuniones de breakout programadas que coincidan con los filtros seleccionados.",
+    "openInvitationsDetail": "Por favor, acceda a todas las salas de reuniones.",
+    "openInvitationsTitle": "Hay invitaciones abiertas.",
+    "title": "Reuniones"
+  },
+  "meetingsCalendar": {
+    "event": {
+      "startTime": "{{startTime, datetime}}",
+      "summary_default": "{{startTime, datetime}}–{{endTime, datetime}}: “{{title}}” por {{creator}}",
+      "summary_recurring": "{{startTime, datetime}}–{{endTime, datetime}}: “{{title}}” por {{creator}}, reunión recurrente"
+    }
+  },
+  "meetingsFilter": {
+    "filterAriaLabel": "Buscar",
+    "filterPlaceholder": "Buscar..."
+  },
+  "meetingsNavigation": {
+    "increaseWidth": "Aumentar el ancho del widget",
+    "increaseWidthToShowMore": "Aumente el ancho del widget para permitir más vistas.",
+    "label": "Ver",
+    "views": {
+      "day": "Dia",
+      "list": "Lista",
+      "month": "Mes",
+      "week": "Semana",
+      "workWeek": "Semana laboral"
+    }
+  },
+  "meetingsPanel": {
+    "actionsTitle": "Acciones",
+    "filtersTitle": "Filtros",
+    "messageToAllBreakoutRoom": {
+      "placeholder": "Enviar un mensaje...",
+      "sendFailed": "Por favor inténtalo de nuevo.",
+      "sendFailedTitle": "No se pudo enviar el mensaje",
+      "sendLabel": "Enviar mensaje para todas las salas",
+      "sendTimeout": "El cambio se envió correctamente y se aplicará pronto.",
+      "sendTimeoutTitle": "El pedido ha sido enviado",
+      "title": "Enviar mensaje a todas las salas de sesiones de breakout"
+    },
+    "scheduleBreakoutSession": "Programar una sesión de breakout",
+    "scheduleMeeting": "Programar reunión",
+    "tabTitle": "Vistas",
+    "tabTitleInvitations": "Invitaciones",
+    "tabTitleMeetings": "Reuniones"
+  },
+  "meetingsToolbar": {
+    "filterAriaLabel": "Buscar",
+    "filterPlaceholder": "Buscar...",
+    "next": {
+      "day": "Día siguiente",
+      "month": "Mes siguiente",
+      "period": "Período siguiente",
+      "week": "Semana siguiente",
+      "workweek": "Próxima semana laboral"
+    },
+    "previous": {
+      "day": "Día anterior",
+      "month": "Mes anterior",
+      "period": "Período anterior",
+      "week": "Semana anterior",
+      "workweek": "Semana laboral anterior"
+    },
+    "today": "Hoy"
+  },
+  "meetingViewEditMeeting": {
+    "breakoutSessionIsOver": "La sesión de breakout ha finalizado y no se puede cambiar.",
+    "meetingIsOver": "La reunión ha finalizado y no se puede cambiar."
+  },
+  "memberSelectionDropdown": {
+    "instructions_one": "{{selectedCount}} de {{count}} entrada seleccionada. Use las teclas de flecha izquierda y derecha para navegar entre ellas. Use las teclas de flecha arriba y abajo para acceder a las opciones disponibles.",
+    "instructions_other": "{{selectedCount}} de {{count}} entrada seleccionada. Use las teclas de flecha izquierda y derecha para navegar entre ellas. Use las teclas de flecha arriba y abajo para acceder a las opciones disponibles.",
+    "loadingError": "No se pudo cargar los usuários disponibles.",
+    "loadingUsers": "Cargando usuarios...",
+    "noMembers": "No hay membros disponibles.",
+    "tagInstructions": "Use la tecla de retroceso para eliminar la entrada."
+  },
+  "openMeetingRoomButton": {
+    "openMeetingRoom": "Abrir sala de reunión",
+    "openMeetingRoom_breakout": "Abrir sala de sesiones de breakout"
+  },
+  "recurrenceEditor": {
+    "custom": {
+      "frequency": {
+        "days": "Días",
+        "months": "Meses",
+        "weeks": "Semanas",
+        "years": "Años"
+      },
+      "frequencyLabel": "Repetir",
+      "intervalLabel": "{{frequencyLabel}} hasta que se repita la reunión",
+      "invalidInput": "Entrada no válida",
+      "monthly": {
+        "byMonthday": "En el día",
+        "byMonthdayLong": "a reunión se repetirá mensualmente en {{nthMonthday}}",
+        "byWeekday": "En",
+        "byWeekdayLong": "La reunión se repetirá mensualmente en {{ordinalLabel}} {{weekday}}",
+        "customRuleMode": "Regla personalizada",
+        "invalidInput": "Entrada no válida",
+        "monthdayInput": "Día"
+      },
+      "repeatEvery": "Repetir cada",
+      "title": "Reunión periódica personalizada",
+      "weekly": {
+        "repeatOnWeekday": "Repetir en el día de la semana"
+      },
+      "yearly": {
+        "byMonthday": "En el día",
+        "byMonthdayLong": "La reunión se repetirá anualmente en {{nthMonthday}} {{month}}",
+        "byWeekday": "En",
+        "byWeekdayLong": "La reunión se repetirá anualmente en {{ordinalLabel}} {{weekday}} of {{month}}",
+        "byWeekdayOf": "de",
+        "customRuleMode": "Regla personalizada",
+        "invalidInput": "Entrada no válida",
+        "monthdayInput": "Día"
+      }
+    },
+    "monthLabel": "Mes",
+    "ordinalLabel": "Ordinal",
+    "ordinals": {
+      "first": "primero",
+      "fourth": "cuarto",
+      "last": "último",
+      "second": "segundo",
+      "third": "tercero"
+    },
+    "recurrencePreset": {
+      "custom": "Personalizado",
+      "daily": "A diario",
+      "mondayToFriday": "De lunes a viernes",
+      "monthly": "Mensualmente",
+      "once": "Sin repetición",
+      "weekly": "Semanalmente",
+      "yearly": "Anualmente"
+    },
+    "recurringMeetingEnd": {
+      "afterMeetingCount": "Después",
+      "afterMeetingCountInput": "Recuento de reuniones",
+      "afterMeetingCountInputUnit": "Reuniones",
+      "afterMeetingCountLong_one": "Termina después de {{count}} reuniones",
+      "afterMeetingCountLong_other": "Termina después de {{count}} reuniones",
+      "endOfRecurringMeeting": "Fin de la reunión periódica",
+      "invalidInput": "Entrada no válida",
+      "never": "Nunca",
+      "neverLong": "La reunión se repetirá para siempre",
+      "untilDate": "En",
+      "untilDateInput": "Fecha de finalización de la reunión periódica",
+      "untilDateInputInvalid": "Fecha no válida",
+      "untilDateInputOpenDatePicker": "Seleccione la fecha en que finaliza la reunión periódica, la fecha seleccionada {{date, datetime}}",
+      "untilDateLong": "La reunión se repetirá hasta {{date,datetime}}"
+    },
+    "repeatMeeting": "Repetir reunión",
+    "ruleText": {
+      "afterMeetingCount_one": "Una vez",
+      "afterMeetingCount_other": "por {{count}} vezes",
+      "daily_one": "Todos day$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "daily_other": "Todos {{count}} days$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_bymonthday_one": "Todos los $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_bymonthday_other": "Cada {{count}} meses, en $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_byweekday_one": "Mensualmente, en {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_byweekday_other": "Cada {{count}} meses, en {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_simple_one": "Todos los  month$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_simple_other": "Cada {{count}} months$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "ordinal_ordinal_one": "{{count}}º",
+      "ordinal_ordinal_two": "{{count}}º",
+      "ordinal_ordinal_few": "{{count}}º",
+      "ordinal_ordinal_other": "{{count}}º",
+      "recurrenceEnd_count": " $t(recurrenceEditor.ruleText.afterMeetingCount, {\"count\": {{afterMeetingCount}}, \"ordinal\": false })",
+      "recurrenceEnd_never": "",
+      "recurrenceEnd_until": " hasta {{ untilDate, datetime(year: 'numeric'; month: 'long'; day: 'numeric') }}",
+      "unknown": "Recurrencia no admitida",
+      "weekly_all_one": "Todos los week$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_all_other": "Todos los {{count}} weeks$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_some_one": "Semanalmente, en {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_some_other": "Cada {{count}} semanas, en {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_weekdays_one": "Todos los weekday$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_weekdays_other": "Cada {{count}} semanas, en weekdays$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_bymonthday_one": "Todos los {{monthLabel}} en $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_bymonthday_other": "Todos los {{count}} años, en $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true }) of {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_byweekday_one": "Todos los {{monthLabel}} en {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_byweekday_other": "Cada {{count}} años, en {{ordinalLabel}} {{byweekday}} of {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_simple_one": "EvTodos losery year$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_simple_other": "Todos los {{count}} years$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })"
+    },
+    "weekdayLabel": "Semanalmente"
+  },
+  "scheduleMeeting": {
+    "allowMessaging": "Permitir enviar mensajes a todos los participantes",
+    "cannotRemoveOwnUser": "No puede eliminar su usuario de la runión.",
+    "description": "Descripción",
+    "endAt": "Finaliza en",
+    "hasPowerToKickUser": "No tiene permiso para eliminar a este participante.",
+    "meetingAlreadyStarted": "La reunión ya ha comenzado.",
+    "participants": "Participantes",
+    "startAt": "Comienza en",
+    "title": "Título (obligatorio)",
+    "titleHelperText": "Es obligatorio un título",
+    "typeToSearch": "Escriba para buscar un usuario...",
+    "youAreAlwaysMember": "El organizador accederá siempre a la reunión."
+  },
+  "scheduleMeetingModal": {
+    "cancel": "Cancelar",
+    "create": "Crear reunión",
+    "scheduleTitle": "Programar reunión"
+  },
+  "setupBreakoutSessions": {
+    "description": "Descripción",
+    "distributeAllRoomMembers": "Distribuir todos los {{amount}} participants",
+    "endAt": "Finaliza en",
+    "groupNumber": "Número de grupo (obligatorio)",
+    "groupNumberErrorMessage": "No hay participantes suficientes para el número de grupos que has introducido.",
+    "groups": "Grupos",
+    "groupTitleDefaultValue": "Grupo {{index}}",
+    "meetingIsOver": "La reunión há finalizado y no puede crear sesiones de breakout.",
+    "notAssignedMessage": "Algunos participantes no están asignados a un grupo.",
+    "notAssignedTitle": "Observación",
+    "startAt": "Comienza en"
+  },
+  "setupBreakoutSessionsModal": {
+    "cancel": "Cancelar",
+    "create": "Crear una sesión de breakout",
+    "title": "Programar una sesión de breakout"
+  },
+  "timeDistance": {
+    "futureText": "{{duration, relativetime}}",
+    "futureTextExact": "en {{duration}}",
+    "remainingText": "Finaliza {{duration, relativetime}}",
+    "remainingTextExact": "Finaliza en {{duration}}"
+  },
+  "widgetSelectionDropdown": {
+    "allActive": "Todos los widgets disponibles están activos.",
+    "instructions_one": "{{selectedCount}} de {{count}} entrada seleccionada. Use las teclas de flecha izquierda y derecha para navegar entre ellas. Use las teclas de flecha arriba y abajo para seleccionar opciones.",
+    "instructions_other": "{{selectedCount}} de {{count}} entrada seleccionada. Use las teclas de flecha izquierda y derecha para navegar entre ellas. Use las teclas de flecha arriba y abajo para seleccionar opciones.",
+    "label": "Widgets",
+    "loading": "Cargando widgets...",
+    "loadingError": "No se pudieron cargar los Widgets disponibles.",
+    "noWidgets": "No hay widgets disponibles.",
+    "tagInstructions": "Use la tecla de retroceso para eliminar la entrada."
   }
-  
+}

--- a/matrix-meetings-widget/public/locales/es/translation.json
+++ b/matrix-meetings-widget/public/locales/es/translation.json
@@ -1,0 +1,418 @@
+{
+    "breakoutSessionGroup": {
+      "groupTitle": "Nombre del grupo (obligatorio)",
+      "groupTitleHelperText": "Es obligatorio un nombre para el grupo",
+      "selectUser": "Seleccione participantes",
+      "youAreAlwaysMember": "El organizador tiene acceso a todas las sesiones de breakout."
+    },
+    "calendarDayPicker": {
+      "chooseDate": "Seleccione la fecha, la fecha seleccionada es {{date, datetime}}",
+      "label": "{{date, datetime}}"
+    },
+    "calendarMonthPicker": {
+      "chooseMonth": "Seleccione el mes, el mes seleccionado es {{date, datetime}}",
+      "label": "{{date, datetime}}"
+    },
+    "calendarWeekPicker": {
+      "chooseWeek": "Seleccione la semana, la semana seleccionada es {{range, daterange}}",
+      "label": "{{range, daterange}}"
+    },
+    "calendarWorkWeekPicker": {
+      "chooseWorkWeek": "Seleccione la semana de trabajo, la semana de trabajo seleccionada es {{range, daterange}}",
+      "label": "{{range, daterange}}"
+    },
+    "cancel": "Cancelar",
+    "close": "Cerrar",
+    "cockpitPanel": {
+      "toParentRoom": "Volver a la sesión de padres"
+    },
+    "copyableTextButton": {
+      "copy-to-clipboard": "Copiar para la carpeta de descargas"
+    },
+    "dateRangePicker": {
+      "chooseDate": "Seleccione el intervalo de fechas, el intervalo seleccionado es {{range, daterange}}",
+      "dateRange": "{{range, daterange}}"
+    },
+    "dateTimePickers": {
+      "endDate": "Fecha de finalización",
+      "endTime": "Hora de finalización",
+      "error": {
+        "breakoutSessionInvalidEndTime": "Las sesiones de breakout tienen que terminar entre {{minDate, datetime}} y {{maxDate, datetime}}.",
+        "breakoutSessionInvalidStartTime": "Las sesiones de breakout tienen que comenzar entre {{minDate, datetime}} y {{maxDate, datetime}}.",
+        "breakoutSessionStartBeforeEnd": "La sesión de grupo debe comenzar antes de que termine.",
+        "meetingStartBeforeEnd": "La reunión debe comenzar antes de que termine.",
+        "meetingStartTooEarly": "La reunión no puede comenzar en el pasado."
+      },
+      "invalidEndDate": "Fecha incorrecta",
+      "invalidEndTime": "Hora incorrecta",
+      "invalidStartDate": "Fecha incorrecta",
+      "invalidStartTime": "Hora incorrecta",
+      "openEndDatePicker": "Seleccione la fecha de finalización, la fecha seleccionada es {{date, datetime}}",
+      "openEndTimePicker": "Seleccione la hora de finalización, la hora seleccionada es {{date, datetime}}",
+      "openStartDatePicker": "Seleccione la fecha de inicio, la fecha seleccionada es {{date, datetime}}",
+      "openStartTimePicker": "Seleccione la hora de inicio, la hora seleccionada es {{date, datetime}}",
+      "startDate": "Fecha de inicio",
+      "startTime": "Hora de inicio"
+    },
+    "editMeetingModal": {
+      "cancel": "Cancelar",
+      "save": "Guardar",
+      "title": "Modificar reunión"
+    },
+    "editRecurringMessage": {
+      "message": "Todas las instancias de la reunión periódica son editables",
+      "titleOne": "Modificar las reuniones periódicas"
+    },
+    "invitedMeetingList": {
+      "detail": {
+        "invitedBy": "Invitado por: {{name}}"
+      }
+    },
+    "invitedMeetingsList": {
+      "title": "Invitaciones"
+    },
+    "meetingCard": {
+      "actions": "Acciones",
+      "deleteInOpenXchangeMenu": "Eliminar reunión en Open-Xchange",
+      "deleteMenu": "Eliminar reunión",
+      "durationSubheader_default": "{{startDate, datetime}} – {{endDate, datetime}}",
+      "durationSubheader_recurring": "$t(meetingCard.durationSubheader_default)<0>. Reaparición: {{recurrence}}</0>",
+      "editInOpenXchangeMenu": "Modificar reunión en Open-Xchange",
+      "editMenu": "Modificar reunión",
+      "editParticipants": {
+        "buttonTitle": "Mostrar participantes",
+        "membership_invite": "Invitado",
+        "membership_join": "Aceptado",
+        "menuTitle": "Participantes"
+      },
+      "meetingRoomWillBeDeleted": "a sala de reunión se eliminará automáticamente {{remainingTime, relativetime}}.",
+      "meetingRoomWillBeDeletedSoon": "La sala de reunión se eliminará automáticamente pronto.",
+      "moreSettings": "Otras configuraciones",
+      "recurrenceTooltip": "Reaparición: {{recurrence}}",
+      "share": {
+        "buttonTitle": "Compartir reunión",
+        "dialInCopyNumber": "Número de acceso",
+        "dialInCopyPin": "Código de acceso",
+        "dialInDescription": "Utilice la siguiente información para acceder a la conferencia usando su teléfono móvil:",
+        "dialInTitle": "Invitar a otras personas",
+        "downloadIcsFile": "Descargar archivos ICS",
+        "emailCopyMessage": "Mensaje",
+        "emailDescription": "Utilice la siguiente información para compartir la conferencia, por ejemplo, por correo electrónico:",
+        "emailTitle": "Compartir la invitación para la reunión",
+        "icsDescription": "Descargar la reunión en formato iCalendar y agregar a la aplicación del calendário:",
+        "icsTitle": "Descargar el archivo de calendario",
+        "linkCopyMeetingLink": "Enlace para la reunión",
+        "linkDescription": "Usa el siguiente enlace para aceder a la reunión:",
+        "linkTitle": "Comparte el enlace para la sala de reunión",
+        "menuTitle": "Compartir reunión",
+        "message": "{{title}}\n\n📅 {{date, daterange}}\n$t(meetingCard.share.messageRecurrence, {\"context\": \"{{recurrenceContext}}\" })\n$t(meetingCard.share.messageDescription, {\"context\": \"{{descriptionContext}}\" })\n__________________________\nRoom: {{link}}\n$t(meetingCard.share.messageDialIn, {\"context\": \"{{dialInContext}}\" })",
+        "messageDescription_none": "",
+        "messageDescription_present": "{{description}}\n",
+        "messageDialIn_none": "",
+        "messageDialIn_nopin": "Número de acceso: {{dialInNumber}}\nDial-In Pin: Pin not required\n",
+        "messageDialIn_pin": "Número de acceso: {{dialInNumber}}\nDial-In Pin: {{dialInPin}}\n",
+        "messageRecurrence_none": "",
+        "messageRecurrence_present": "🔁 Reaparición: {{recurrence}}\n",
+        "shareByMail": "Compartir por correo electrónico",
+        "shareDialInNumber": "Compartir número de acceso",
+        "shareDialInNumberError": "Error al cargar la información de acceso.",
+        "shareDialInNumberNotPresent": "No hay información de acceso disponible",
+        "shareLink": "Compartir el enlace para la reunión",
+        "warningRecurringMeetingDialInNumber": "Este es un número de acceso para el ciclo de reuniones. Al compartir este número de acceso, invitas a los usuarios a todas las reuniones siguientes.",
+        "warningRecurringMeetingEmail": "Este es un correo electrónico de invitación para el ciclo de reuniones. Al compartir este correo electrónico, invitas a los usuarios a todas las reuniones siguientes.",
+        "warningRecurringMeetingICalFile": "Este es un archivo iCal para el ciclo de reuniones. Al compartir este archivo, invitas a los usuarios a todas las reuniones siguientes.",
+        "warningRecurringMeetingLink": "Este es un enlace de acceso al ciclo de reuniones. Al compartir este enlace, invitas a los usuarios a todas las reuniones siguientes."
+      },
+      "updateFailed": "Por favor, inténtelo de nuevo",
+      "updateFailedClose": "Cerrar",
+      "updateFailedTitle": "No se pudo actualizar la reunión"
+    },
+    "meetingDetails": {
+      "content": {
+        "dateAndTime": "{{range, daterange}}",
+        "description": "Descripción",
+        "details": "Descripción",
+        "organizer": "Organizador",
+        "participants": "Participantes",
+        "shareMeeting": {
+          "download": "Descargar",
+          "downloadIcsFile": "Descargar el archivo ICS",
+          "emailCopyMessage": "Mensaje",
+          "emailDescription": "Utilice la siguiente información para compartir la conferencia, por ejemplo por correo electrónico:",
+          "emailTitle": "Compartir la invitación a la reunión",
+          "icsDescription": "Descargar la reunión en formato iCalendar y agregarla a la aplicación de calendario:",
+          "icsTitle": "Descargar un archivo del calendario",
+          "shareByMail": "Compartir por correo electrónico",
+          "title": "Compartir reunión",
+          "warningRecurringMeetingEmail": "Este es un correo electrónico de invitación para el ciclo de reuniones. Al compartir este correo electrónico, invitas a los usuarios a todas las reuniones siguientes.",
+          "warningRecurringMeetingICalFile": "Este es un archivo iCal para el ciclo de reuniones. Al compartir este archivo, invitas a los usuarios a todas las reuniones siguientes."
+        }
+      },
+      "header": {
+        "deleteConfirmButton": "Eliminar",
+        "deleteConfirmHeader": "Eliminar reunión",
+        "deleteConfirmMessage": "¿Está seguro de que desea eliminar la reunión “{{title}}” a las {{startTime, datetime}} y todo el contenido relacionado con ella?",
+        "deleteFailed": "Por favor, inténtelo de nuevo.",
+        "deleteFailedTitle": "No se pudo eliminar la reunión",
+        "deleteInOpenXchangeMenu": "Eliminar reunión en Open-Xchange",
+        "deleteMeetingConfirmButton": "Eliminar reunión",
+        "deleteMenu": "Eliminar",
+        "deleteSeriesConfirmButton": "Eliminar serie",
+        "deleteSeriesConfirmMessage": "¿Está seguro de que desea eliminar la reunión o el ciclo de reuniones “{{title}}” a las {{startTime, datetime}} y todo el contenido relacionado con ella?",
+        "editInOpenXchangeMenu": "Modificar reunión en Open-Xchange",
+        "editMenu": "Modificar",
+        "join": "Acceder",
+        "joinBreakout_breakout": "Acceder"
+      }
+    },
+    "meetingHasBreakoutSessionsWarning": {
+      "message": "Si desea cambiar la hora de inicio o finalización de esta reunión, las sesiones de breakout no se moverán!",
+      "title": "La reunión ya cuenta con sesiones de breakout."
+    },
+    "meetingInvitationGuard": {
+      "meetingInvitation": "Por favor, acepte la invitación a la reunión para ver todos los detalles."
+    },
+    "meetingList": {
+      "groupTitle": "{{date, datetime}}",
+      "noBreakoutSessionsScheduled": "No hay sesiones de breakout programadas que coincidan con los filtros seleccionados.",
+      "noMeetingsScheduled": "No hay reuniones de breakout programadas que coincidan con los filtros seleccionados.",
+      "openInvitationsDetail": "Por favor, acceda a todas las salas de reuniones.",
+      "openInvitationsTitle": "Hay invitaciones abiertas.",
+      "title": "Reuniones"
+    },
+    "meetingsCalendar": {
+      "event": {
+        "startTime": "{{startTime, datetime}}",
+        "summary_default": "{{startTime, datetime}}–{{endTime, datetime}}: “{{title}}” por {{creator}}",
+        "summary_recurring": "{{startTime, datetime}}–{{endTime, datetime}}: “{{title}}” por {{creator}}, reunión recurrente"
+      }
+    },
+    "meetingsFilter": {
+      "filterAriaLabel": "Buscar",
+      "filterPlaceholder": "Buscar..."
+    },
+    "meetingsNavigation": {
+      "increaseWidth": "Aumentar el ancho del widget",
+      "increaseWidthToShowMore": "Aumente el ancho del widget para permitir más vistas.",
+      "label": "Ver",
+      "views": {
+        "day": "Dia",
+        "list": "Lista",
+        "month": "Mes",
+        "week": "Semana",
+        "workWeek": "Semana laboral"
+      }
+    },
+    "meetingsPanel": {
+      "actionsTitle": "Acciones",
+      "filtersTitle": "Filtros",
+      "messageToAllBreakoutRoom": {
+        "placeholder": "Enviar un mensaje...",
+        "sendFailed": "Por favor inténtalo de nuevo.",
+        "sendFailedTitle": "No se pudo enviar el mensaje",
+        "sendLabel": "Enviar mensaje para todas las salas",
+        "sendTimeout": "El cambio se envió correctamente y se aplicará pronto.",
+        "sendTimeoutTitle": "El pedido ha sido enviado",
+        "title": "Enviar mensaje a todas las salas de sesiones de breakout"
+      },
+      "scheduleBreakoutSession": "Programar una sesión de breakout",
+      "scheduleMeeting": "Programar reunión",
+      "tabTitle": "Vistas",
+      "tabTitleInvitations": "Invitaciones",
+      "tabTitleMeetings": "Reuniones"
+    },
+    "meetingsToolbar": {
+      "filterAriaLabel": "Buscar",
+      "filterPlaceholder": "Buscar...",
+      "next": {
+        "day": "Día siguiente",
+        "month": "Mes siguiente",
+        "period": "Período siguiente",
+        "week": "Semana siguiente",
+        "workweek": "Próxima semana laboral"
+      },
+      "previous": {
+        "day": "Día anterior",
+        "month": "Mes anterior",
+        "period": "Período anterior",
+        "week": "Semana anterior",
+        "workweek": "Semana laboral anterior"
+      },
+      "today": "Hoy"
+    },
+    "meetingViewEditMeeting": {
+      "breakoutSessionIsOver": "La sesión de breakout ha finalizado y no se puede cambiar.",
+      "meetingIsOver": "La reunión ha finalizado y no se puede cambiar."
+    },
+    "memberSelectionDropdown": {
+      "instructions_one": "{{selectedCount}} de {{count}} entrada seleccionada. Use las teclas de flecha izquierda y derecha para navegar entre ellas. Use las teclas de flecha arriba y abajo para acceder a las opciones disponibles.",
+      "instructions_other": "{{selectedCount}} de {{count}} entrada seleccionada. Use las teclas de flecha izquierda y derecha para navegar entre ellas. Use las teclas de flecha arriba y abajo para acceder a las opciones disponibles.",
+      "loadingError": "No se pudo cargar los usuários disponibles.",
+      "loadingUsers": "Cargando usuarios...",
+      "noMembers": "No hay membros disponibles.",
+      "tagInstructions": "Use la tecla de retroceso para eliminar la entrada."
+    },
+    "openMeetingRoomButton": {
+      "openMeetingRoom": "Abrir sala de reunión",
+      "openMeetingRoom_breakout": "Abrir sala de sesiones de breakout"
+    },
+    "recurrenceEditor": {
+      "custom": {
+        "frequency": {
+          "days": "Días",
+          "months": "Meses",
+          "weeks": "Semanas",
+          "years": "Años"
+        },
+        "frequencyLabel": "Repetir",
+        "intervalLabel": "{{frequencyLabel}} hasta que se repita la reunión",
+        "invalidInput": "Entrada no válida",
+        "monthly": {
+          "byMonthday": "En el día",
+          "byMonthdayLong": "a reunión se repetirá mensualmente en {{nthMonthday}}",
+          "byWeekday": "En",
+          "byWeekdayLong": "La reunión se repetirá mensualmente en {{ordinalLabel}} {{weekday}}",
+          "customRuleMode": "Regla personalizada",
+          "invalidInput": "Entrada no válida",
+          "monthdayInput": "Día"
+        },
+        "repeatEvery": "Repetir cada",
+        "title": "Reunión periódica personalizada",
+        "weekly": {
+          "repeatOnWeekday": "Repetir en el día de la semana"
+        },
+        "yearly": {
+          "byMonthday": "En el día",
+          "byMonthdayLong": "La reunión se repetirá anualmente en {{nthMonthday}} {{month}}",
+          "byWeekday": "En",
+          "byWeekdayLong": "La reunión se repetirá anualmente en {{ordinalLabel}} {{weekday}} of {{month}}",
+          "byWeekdayOf": "de",
+          "customRuleMode": "Regla personalizada",
+          "invalidInput": "Entrada no válida",
+          "monthdayInput": "Día"
+        }
+      },
+      "monthLabel": "Mes",
+      "ordinalLabel": "Ordinal",
+      "ordinals": {
+        "first": "primero",
+        "fourth": "cuarto",
+        "last": "último",
+        "second": "segundo",
+        "third": "tercero"
+      },
+      "recurrencePreset": {
+        "custom": "Personalizado",
+        "daily": "A diario",
+        "mondayToFriday": "De lunes a viernes",
+        "monthly": "Mensualmente",
+        "once": "Sin repetición",
+        "weekly": "Semanalmente",
+        "yearly": "Anualmente"
+      },
+      "recurringMeetingEnd": {
+        "afterMeetingCount": "Después",
+        "afterMeetingCountInput": "Recuento de reuniones",
+        "afterMeetingCountInputUnit": "Reuniones",
+        "afterMeetingCountLong_one": "Termina después de {{count}} reuniones",
+        "afterMeetingCountLong_other": "Termina después de {{count}} reuniones",
+        "endOfRecurringMeeting": "Fin de la reunión periódica",
+        "invalidInput": "Entrada no válida",
+        "never": "Nunca",
+        "neverLong": "La reunión se repetirá para siempre",
+        "untilDate": "En",
+        "untilDateInput": "Fecha de finalización de la reunión periódica",
+        "untilDateInputInvalid": "Fecha no válida",
+        "untilDateInputOpenDatePicker": "Seleccione la fecha en que finaliza la reunión periódica, la fecha seleccionada {{date, datetime}}",
+        "untilDateLong": "La reunión se repetirá hasta {{date,datetime}}"
+      },
+      "repeatMeeting": "Repetir reunión",
+      "ruleText": {
+        "afterMeetingCount_one": "Una vez",
+        "afterMeetingCount_other": "por {{count}} vezes",
+        "daily_one": "Todos day$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "daily_other": "Todos {{count}} days$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_bymonthday_one": "Todos los $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_bymonthday_other": "Cada {{count}} meses, en $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_byweekday_one": "Mensualmente, en {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_byweekday_other": "Cada {{count}} meses, en {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_simple_one": "Todos los  month$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_simple_other": "Cada {{count}} months$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "ordinal_ordinal_one": "{{count}}º",
+        "ordinal_ordinal_two": "{{count}}º",
+        "ordinal_ordinal_few": "{{count}}º",
+        "ordinal_ordinal_other": "{{count}}º",
+        "recurrenceEnd_count": " $t(recurrenceEditor.ruleText.afterMeetingCount, {\"count\": {{afterMeetingCount}}, \"ordinal\": false })",
+        "recurrenceEnd_never": "",
+        "recurrenceEnd_until": " hasta {{ untilDate, datetime(year: 'numeric'; month: 'long'; day: 'numeric') }}",
+        "unknown": "Recurrencia no admitida",
+        "weekly_all_one": "Todos los week$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "weekly_all_other": "Todos los {{count}} weeks$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "weekly_some_one": "Semanalmente, en {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "weekly_some_other": "Cada {{count}} semanas, en {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "weekly_weekdays_one": "Todos los weekday$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "weekly_weekdays_other": "Cada {{count}} semanas, en weekdays$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_bymonthday_one": "Todos los {{monthLabel}} en $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_bymonthday_other": "Todos los {{count}} años, en $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true }) of {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_byweekday_one": "Todos los {{monthLabel}} en {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_byweekday_other": "Cada {{count}} años, en {{ordinalLabel}} {{byweekday}} of {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_simple_one": "EvTodos losery year$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_simple_other": "Todos los {{count}} years$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })"
+      },
+      "weekdayLabel": "Semanalmente"
+    },
+    "scheduleMeeting": {
+      "allowMessaging": "Permitir enviar mensajes a todos los participantes",
+      "cannotRemoveOwnUser": "No puede eliminar su usuario de la runión.",
+      "description": "Descripción",
+      "endAt": "Finaliza en",
+      "hasPowerToKickUser": "No tiene permiso para eliminar a este participante.",
+      "meetingAlreadyStarted": "La reunión ya ha comenzado.",
+      "participants": "Participantes",
+      "startAt": "Comienza en",
+      "title": "Título (obligatorio)",
+      "titleHelperText": "Es obligatorio un título",
+      "typeToSearch": "Escriba para buscar un usuario...",
+      "youAreAlwaysMember": "El organizador accederá siempre a la reunión."
+    },
+    "scheduleMeetingModal": {
+      "cancel": "Cancelar",
+      "create": "Crear reunión",
+      "scheduleTitle": "Programar reunión"
+    },
+    "setupBreakoutSessions": {
+      "description": "Descripción",
+      "distributeAllRoomMembers": "Distribuir todos los {{amount}} participants",
+      "endAt": "Finaliza en",
+      "groupNumber": "Número de grupo (obligatorio)",
+      "groupNumberErrorMessage": "No hay participantes suficientes para el número de grupos que has introducido.",
+      "groups": "Grupos",
+      "groupTitleDefaultValue": "Grupo {{index}}",
+      "meetingIsOver": "La reunión há finalizado y no puede crear sesiones de breakout.",
+      "notAssignedMessage": "Algunos participantes no están asignados a un grupo.",
+      "notAssignedTitle": "Observación",
+      "startAt": "Comienza en"
+    },
+    "setupBreakoutSessionsModal": {
+      "cancel": "Cancelar",
+      "create": "Crear una sesión de breakout",
+      "title": "Programar una sesión de breakout"
+    },
+    "timeDistance": {
+      "futureText": "{{duration, relativetime}}",
+      "futureTextExact": "en {{duration}}",
+      "remainingText": "Finaliza {{duration, relativetime}}",
+      "remainingTextExact": "Finaliza en {{duration}}"
+    },
+    "widgetSelectionDropdown": {
+      "allActive": "Todos los widgets disponibles están activos.",
+      "instructions_one": "{{selectedCount}} de {{count}} entrada seleccionada. Use las teclas de flecha izquierda y derecha para navegar entre ellas. Use las teclas de flecha arriba y abajo para seleccionar opciones.",
+      "instructions_other": "{{selectedCount}} de {{count}} entrada seleccionada. Use las teclas de flecha izquierda y derecha para navegar entre ellas. Use las teclas de flecha arriba y abajo para seleccionar opciones.",
+      "label": "Widgets",
+      "loading": "Cargando widgets...",
+      "loadingError": "No se pudieron cargar los Widgets disponibles.",
+      "noWidgets": "No hay widgets disponibles.",
+      "tagInstructions": "Use la tecla de retroceso para eliminar la entrada."
+    }
+  }
+  

--- a/matrix-meetings-widget/public/locales/fr/translation.json
+++ b/matrix-meetings-widget/public/locales/fr/translation.json
@@ -1,418 +1,417 @@
 {
-    "breakoutSessionGroup": {
-      "groupTitle": "Nom du groupe (obligatoire)",
-      "groupTitleHelperText": "Il faut un nom pour le groupe",
-      "selectUser": "Sélectionner participants",
-      "youAreAlwaysMember": "L’organisateur va accéder à toutes les séances de groupes."
+  "breakoutSessionGroup": {
+    "groupTitle": "Nom du groupe (obligatoire)",
+    "groupTitleHelperText": "Il faut un nom pour le groupe",
+    "selectUser": "Sélectionner participants",
+    "youAreAlwaysMember": "L’organisateur va accéder à toutes les séances de groupes."
+  },
+  "calendarDayPicker": {
+    "chooseDate": "Sélectionnez la date, la date sélectionnée est {{date, datetime}}",
+    "label": "{{date, datetime}}"
+  },
+  "calendarMonthPicker": {
+    "chooseMonth": "Sélectionnez le mois, le mois sélectionné est {{date, datetime}}",
+    "label": "{{date, datetime}}"
+  },
+  "calendarWeekPicker": {
+    "chooseWeek": "Sélectionnez la semaine, la semaine sélectionnée est {{range, daterange}}",
+    "label": "{{range, daterange}}"
+  },
+  "calendarWorkWeekPicker": {
+    "chooseWorkWeek": "Sélectionnez la semaine de travail, la semaine de travail sélectionnée est {{range, daterange}}",
+    "label": "{{range, daterange}}"
+  },
+  "cancel": "Annuler",
+  "close": "Fermer",
+  "cockpitPanel": {
+    "toParentRoom": "Rentrer dans la salle des parents"
+  },
+  "copyableTextButton": {
+    "copy-to-clipboard": "Copier pour la presse-papiers"
+  },
+  "dateRangePicker": {
+    "chooseDate": "Sélectionnez une plage de dates, la plage de dates sélectionnée est {{range, daterange}}",
+    "dateRange": "{{range, daterange}}"
+  },
+  "dateTimePickers": {
+    "endDate": "Date de fin",
+    "endTime": "Heure de la fin",
+    "error": {
+      "breakoutSessionInvalidEndTime": "Les séances de groupe doivent terminer entre {{minDate, datetime}} et {{maxDate, datetime}}.",
+      "breakoutSessionInvalidStartTime": "Les séances de groupe doivent commencer entre {{minDate, datetime}} et {{maxDate, datetime}}.",
+      "breakoutSessionStartBeforeEnd": "La date et l’heure des séances de groupe doivent être antérieures à la date et à l’heure de la fin.",
+      "meetingStartBeforeEnd": "La date et l’heure de la réunion doivent être antérieures à la date et à l’heure de la fin.",
+      "meetingStartTooEarly": "La date et l’heure de la réunion doivent être postérieures à la date et à l’heure actuelles."
     },
-    "calendarDayPicker": {
-      "chooseDate": "Sélectionnez la date, la date sélectionnée est {{date, datetime}}",
-      "label": "{{date, datetime}}"
-    },
-    "calendarMonthPicker": {
-      "chooseMonth": "Sélectionnez le mois, le mois sélectionné est {{date, datetime}}",
-      "label": "{{date, datetime}}"
-    },
-    "calendarWeekPicker": {
-      "chooseWeek": "Sélectionnez la semaine, la semaine sélectionnée est {{range, daterange}}",
-      "label": "{{range, daterange}}"
-    },
-    "calendarWorkWeekPicker": {
-      "chooseWorkWeek": "Sélectionnez la semaine de travail, la semaine de travail sélectionnée est {{range, daterange}}",
-      "label": "{{range, daterange}}"
-    },
+    "invalidEndDate": "Date incorrecte",
+    "invalidEndTime": "Heure incorrecte",
+    "invalidStartDate": "Date incorrecte",
+    "invalidStartTime": "Heure incorrecte",
+    "openEndDatePicker": "Sélectionnez la date de fin, la date sélectionnée est {{date, datetime}}",
+    "openEndTimePicker": "Sélectionnez l’heure de fin, l’heure sélectionnée est  {{date, datetime}}",
+    "openStartDatePicker": "Sélectionnez la date de début, la date sélectionnée est {{date, datetime}}",
+    "openStartTimePicker": "Sélectionnez l´heure de début, l´heure sélectionnée est {{date, datetime}}",
+    "startDate": "Date de début",
+    "startTime": "Heure de début"
+  },
+  "editMeetingModal": {
     "cancel": "Annuler",
-    "close": "Fermer",
-    "cockpitPanel": {
-      "toParentRoom": "Rentrer dans la salle des parents"
-    },
-    "copyableTextButton": {
-      "copy-to-clipboard": "Copier pour la presse-papiers"
-    },
-    "dateRangePicker": {
-      "chooseDate": "Sélectionnez une plage de dates, la plage de dates sélectionnée est {{range, daterange}}",
-      "dateRange": "{{range, daterange}}"
-    },
-    "dateTimePickers": {
-      "endDate": "Date de fin",
-      "endTime": "Heure de la fin",
-      "error": {
-        "breakoutSessionInvalidEndTime": "Les séances de groupe doivent terminer entre {{minDate, datetime}} et {{maxDate, datetime}}.",
-        "breakoutSessionInvalidStartTime": "Les séances de groupe doivent commencer entre {{minDate, datetime}} et {{maxDate, datetime}}.",
-        "breakoutSessionStartBeforeEnd": "La date et l’heure des séances de groupe doivent être antérieures à la date et à l’heure de la fin.",
-        "meetingStartBeforeEnd": "La date et l’heure de la réunion doivent être antérieures à la date et à l’heure de la fin.",
-        "meetingStartTooEarly": "La date et l’heure de la réunion doivent être postérieures à la date et à l’heure actuelles."
-      },
-      "invalidEndDate": "Date incorrecte",
-      "invalidEndTime": "Heure incorrecte",
-      "invalidStartDate": "Date incorrecte",
-      "invalidStartTime": "Heure incorrecte",
-      "openEndDatePicker": "Sélectionnez la date de fin, la date sélectionnée est {{date, datetime}}",
-      "openEndTimePicker": "Sélectionnez l’heure de fin, l’heure sélectionnée est  {{date, datetime}}",
-      "openStartDatePicker": "Sélectionnez la date de début, la date sélectionnée est {{date, datetime}}",
-      "openStartTimePicker": "Sélectionnez l´heure de début, l´heure sélectionnée est {{date, datetime}}",
-      "startDate": "Date de début",
-      "startTime": "Heure de début"
-    },
-    "editMeetingModal": {
-      "cancel": "Annuler",
-      "save": "Enregistrer",
-      "title": "Modifier réunion"
-    },
-    "editRecurringMessage": {
-      "message": "Toutes les définitionsde de la réunion récurrente sont modifiables",
-      "titleOne": "Modifier la série des réunions récurrentes"
-    },
-    "invitedMeetingList": {
-      "detail": {
-        "invitedBy": "Invité par: {{name}}"
-      }
-    },
-    "invitedMeetingsList": {
-      "title": "Invitations"
-    },
-    "meetingCard": {
-      "actions": "Actions",
-      "deleteInOpenXchangeMenu": "Effacer réunion en Open-Xchange",
-      "deleteMenu": "Effacer réunion",
-      "durationSubheader_default": "{{startDate, datetime}} – {{endDate, datetime}}",
-      "durationSubheader_recurring": "$t(meetingCard.durationSubheader_default)<0>. Récurrence: {{recurrence}}</0>",
-      "editInOpenXchangeMenu": "Modifier réunion en Open-Xchange",
-      "editMenu": "Modifier réunion",
-      "editParticipants": {
-        "buttonTitle": "Montrer participants",
-        "membership_invite": "Invité",
-        "membership_join": "Accepté",
-        "menuTitle": "Participants"
-      },
-      "meetingRoomWillBeDeleted": "La salle de réunion va être supprimée automatiquement {{remainingTime, relativetime}}.",
-      "meetingRoomWillBeDeletedSoon": "La salle de réunion va être supprimée  bientôt automatiquement.",
-      "moreSettings": "Plus configurations",
-      "recurrenceTooltip": "Récurrences: {{recurrence}}",
-      "share": {
-        "buttonTitle": "Partager réunion",
-        "dialInCopyNumber": "Nombre d’accès",
-        "dialInCopyPin": "PIN d’accès",
-        "dialInDescription": "Utilisez l´information suivante pour accèder à la conférence à partir du téléphone portable:",
-        "dialInTitle": "Inviter autres personnes",
-        "downloadIcsFile": "Transférer fichier ICS",
-        "emailCopyMessage": "Message",
-        "emailDescription": "Utilisez l’information suivante pour partager la conférence, par exemple, par email:",
-        "emailTitle": "Partager l’invitation pour la réunion",
-        "icsDescription": "Transférer la réunion en format iCalendar et addicionner à l’application de calendrier:",
-        "icsTitle": "Transférer le fichier de calendrier",
-        "linkCopyMeetingLink": "Lien pour la réunion",
-        "linkDescription": "Utilisez le lien suivant pour accèder à la réunion:",
-        "linkTitle": "Partagez le lien pour la salle de réunion",
-        "menuTitle": "Partager réunion",
-        "message": "{{title}}\n\n📅 {{date, daterange}}\n$t(meetingCard.share.messageRecurrence, {\"context\": \"{{recurrenceContext}}\" })\n$t(meetingCard.share.messageDescription, {\"context\": \"{{descriptionContext}}\" })\n__________________________\nRoom: {{link}}\n$t(meetingCard.share.messageDialIn, {\"context\": \"{{dialInContext}}\" })",
-        "messageDescription_none": "",
-        "messageDescription_present": "{{description}}\n",
-        "messageDialIn_none": "",
-        "messageDialIn_nopin": "Nombre d’accès: {{dialInNumber}}\nDial-In Pin: Pin not required\n",
-        "messageDialIn_pin": "Nombre d’accès: {{dialInNumber}}\nDial-In Pin: {{dialInPin}}\n",
-        "messageRecurrence_none": "",
-        "messageRecurrence_present": "🔁 Récurrence: {{recurrence}}\n",
-        "shareByMail": "Partager par courriel",
-        "shareDialInNumber": "Partager le nombre d’accès",
-        "shareDialInNumberError": "Erreur en chargeant les informations d’accès.",
-        "shareDialInNumberNotPresent": "Sans information d’accès disponible",
-        "shareLink": "Partager le lien de la réunion",
-        "warningRecurringMeetingDialInNumber": "C’est le nombre d’accès pour la série de réunions. En partageant ce nombre d’accès, invite les utilisateurs pour toutes les réunions de la série.",
-        "warningRecurringMeetingEmail": "C’est un email d’invitation  pour la série de réunions. En partageant ce courriel, invite les utilisateurs pour toutes les réunions de la série.",
-        "warningRecurringMeetingICalFile": "C’est un fichier       pour la série de réunions. En partageant ce fichier, invite les utilisateurs pour toutes les réunions de la série.",
-        "warningRecurringMeetingLink": "C’est un lien d’accès pour la série de réunions. En partageant ce lien, invite les utilisateurs pour toutes les réunions de la série."
-      },
-      "updateFailed": "S’il vous plaît, essayer à nouveau",
-      "updateFailedClose": "Fermer",
-      "updateFailedTitle": "Défaut en actualisant la réunion"
-    },
-    "meetingDetails": {
-      "content": {
-        "dateAndTime": "{{range, daterange}}",
-        "description": "Description",
-        "details": "Détails",
-        "organizer": "Organisateur",
-        "participants": "Participants",
-        "shareMeeting": {
-          "download": "Transférer",
-          "downloadIcsFile": "Transférer le fichier ICS",
-          "emailCopyMessage": "Message",
-          "emailDescription": "Utilisez l´information suivante pour partager la conférence, par exemple, par email:",
-          "emailTitle": "Partager l´invitaton pour la réunion",
-          "icsDescription": "Transférer la réunion en format iCalendar et additionner à l’aplication du calendrier:",
-          "icsTitle": "Transférer un fichier de calendrier",
-          "shareByMail": "Transférer par email",
-          "title": "Partager réunion",
-          "warningRecurringMeetingEmail": "C’est un email d’invitation pour la série de réunions. En partageant cet email, invite les utilisateurs pour toutes les réunions de la série.",
-          "warningRecurringMeetingICalFile": "C’est un fichier iCal pour la série de réunions. En partageant ce fichier, invite les utilisateurs pour toutes les réunions de la série."
-        }
-      },
-      "header": {
-        "deleteConfirmButton": "Effacer",
-        "deleteConfirmHeader": "Effacer réunion",
-        "deleteConfirmMessage": "Êtes-vous sûr que vous voulez effacer la réunion “{{title}}” en {{startTime, datetime}} et tout le contenu associé?",
-        "deleteFailed": "S’il vous plaît, essayez à nouveau.",
-        "deleteFailedTitle": "Défaut en effaçant la réunion",
-        "deleteInOpenXchangeMenu": "Effacer la réunion Open-Xchange",
-        "deleteMeetingConfirmButton": "Effacer réunion",
-        "deleteMenu": "Effacer",
-        "deleteSeriesConfirmButton": "Effacer série",
-        "deleteSeriesConfirmMessage": "Êtes-vous sûr que vous voulez effacer la réunion ou la série de réunions “{{title}}” en {{startTime, datetime}} et tout le contenu associé?",
-        "editInOpenXchangeMenu": "Éditer réunion en Open-Xchange",
-        "editMenu": "Éditer",
-        "join": "Accéder",
-        "joinBreakout_breakout": "Accéder"
-      }
-    },
-    "meetingHasBreakoutSessionsWarning": {
-      "message": "Si vous voulez changer l’heure du début ou fin de cette réunion, les séances de groupe ne seront pas déplacés!",
-      "title": "La réunion a déjà des séances de groupe."
-    },
-    "meetingInvitationGuard": {
-      "meetingInvitation": "S’il vous plaît, acceptez l’invitation pour la réunion  pour voir tous les détails."
-    },
-    "meetingList": {
-      "groupTitle": "{{date, datetime}}",
-      "noBreakoutSessionsScheduled": "Il n’y a pas de séances de groupe prévus qui correspondent aux filtres sélectionnés.",
-      "noMeetingsScheduled": "Il n’y a pas de réunions prévues qui correspondent aux filtres sélectionnés.",
-      "openInvitationsDetail": "S’il vous plaît, accédez à toutes les salles de réunions.",
-      "openInvitationsTitle": "Il y a des invitations ouvertes.",
-      "title": "Réunions"
-    },
-    "meetingsCalendar": {
-      "event": {
-        "startTime": "{{startTime, datetime}}",
-        "summary_default": "{{startTime, datetime}}–{{endTime, datetime}}: “{{title}}” pour {{creator}}",
-        "summary_recurring": "{{startTime, datetime}}–{{endTime, datetime}}: “{{title}}” pour {{creator}}, réunion récurrente"
-      }
-    },
-    "meetingsFilter": {
-      "filterAriaLabel": "Chercher",
-      "filterPlaceholder": "Chercher..."
-    },
-    "meetingsNavigation": {
-      "increaseWidth": "Augmenter la largeur du widget",
-      "increaseWidthToShowMore": "Augmenter la largeur du widget pour permettre plus de visualisations.",
-      "label": "Visualiser",
-      "views": {
-        "day": "Jour",
-        "list": "Liste",
-        "month": "Mois",
-        "week": "Semaine",
-        "workWeek": "Semaine ouvrable"
-      }
-    },
-    "meetingsPanel": {
-      "actionsTitle": "Actions",
-      "filtersTitle": "Filtres",
-      "messageToAllBreakoutRoom": {
-        "placeholder": "Envoyer un message...",
-        "sendFailed": "S’il vous plaît, essayez à nouveau.",
-        "sendFailedTitle": "Défaut en envoyant le message",
-        "sendLabel": "Envoyer message pour toutes les salles",
-        "sendTimeout": "La modification a été soumise avec succès et sera appliquée bientôt.",
-        "sendTimeoutTitle": "La demande a été envoyée",
-        "title": "Envoyer message pour toutes les salles de séances de groupes"
-      },
-      "scheduleBreakoutSession": "Programmer séance de groupe",
-      "scheduleMeeting": "Programmer réunion",
-      "tabTitle": "Visualisations",
-      "tabTitleInvitations": "Invitations",
-      "tabTitleMeetings": "Réunions"
-    },
-    "meetingsToolbar": {
-      "filterAriaLabel": "Chercher",
-      "filterPlaceholder": "Chercher...",
-      "next": {
-        "day": "Jour suivant",
-        "month": "Mois suivant",
-        "period": "Période suivante",
-        "week": "Semaine suivante",
-        "workweek": "Prochaine semaine ouvrable"
-      },
-      "previous": {
-        "day": "Jour précédent",
-        "month": "Mois précédent",
-        "period": "Période précédente",
-        "week": "Semaine précédente",
-        "workweek": "Semaine ouvrable précédente"
-      },
-      "today": "Aujourd’hui"
-    },
-    "meetingViewEditMeeting": {
-      "breakoutSessionIsOver": "La séance de groupe a déjà terminé et ne peut pas être changé.",
-      "meetingIsOver": "La réunion a déjà terminé et ne peut pas être changé."
-    },
-    "memberSelectionDropdown": {
-      "instructions_one": "{{selectedCount}} de {{count}} entrée sélectionnée. Utilisez les touches flèches vers la gauche et vers la droite pour surfer entre elles. Utilisez les touches flèches vers le haut et vers le bas pour accéder aux options disponibles.",
-      "instructions_other": "{{selectedCount}} de {{count}} entrée sélectionnée. Utilisez les touches flèches vers la gauche et vers la droite pour surfer entre elles. Utilisez les touches flèches vers le haut et vers le bas pour accéder aux options disponibles.",
-      "loadingError": "Erreur lors du chargement des utilisateurs disponibles.",
-      "loadingUsers": "En chargeant utilisateurs...",
-      "noMembers": "Sans membres disponibles.",
-      "tagInstructions": "Utilisez le bouton Espace Arrière/Backspace pour effacer l’entrée."
-    },
-    "openMeetingRoomButton": {
-      "openMeetingRoom": "Ouvrir la salle de réunion",
-      "openMeetingRoom_breakout": "Ouvrir la salle des séances de groupe"
-    },
-    "recurrenceEditor": {
-      "custom": {
-        "frequency": {
-          "days": "Jours",
-          "months": "Mois",
-          "weeks": "Semaines",
-          "years": "Années"
-        },
-        "frequencyLabel": "Répéter",
-        "intervalLabel": "{{frequencyLabel}} jusqu’à ce que cette réunion soit répétée",
-        "invalidInput": "Entrée incorrecte",
-        "monthly": {
-          "byMonthday": "Le jour",
-          "byMonthdayLong": "La réunion sera répétée mensuellement en {{nthMonthday}}",
-          "byWeekday": "En",
-          "byWeekdayLong": "La réunion sera répétée mensuellement en {{ordinalLabel}} {{weekday}}",
-          "customRuleMode": "Règle personalisée",
-          "invalidInput": "Entrée incorrecte",
-          "monthdayInput": "Jour"
-        },
-        "repeatEvery": "Répéter à chaque",
-        "title": "Réunion récurrente personalisée",
-        "weekly": {
-          "repeatOnWeekday": "Répéter dans le jour de la semaine"
-        },
-        "yearly": {
-          "byMonthday": "Le jour",
-          "byMonthdayLong": "La réunion sera répétée annuellement en {{nthMonthday}} {{month}}",
-          "byWeekday": "Dans le",
-          "byWeekdayLong": "La réunion sera répétée annuellement en {{ordinalLabel}} {{weekday}} de {{month}}",
-          "byWeekdayOf": "de",
-          "customRuleMode": "Règle personnalisée",
-          "invalidInput": "Entrée incorrecte",
-          "monthdayInput": "Jour"
-        }
-      },
-      "monthLabel": "Mois",
-      "ordinalLabel": "Ordinal",
-      "ordinals": {
-        "first": "premier",
-        "fourth": "quatrième",
-        "last": "dernier",
-        "second": "deuxième",
-        "third": "troisième"
-      },
-      "recurrencePreset": {
-        "custom": "Personnalisée",
-        "daily": "Tous les jours",
-        "mondayToFriday": "De lundi à vendredi",
-        "monthly": "Mensuellement",
-        "once": "Sans répétition",
-        "weekly": "Par semaine",
-        "yearly": "Annuellement"
-      },
-      "recurringMeetingEnd": {
-        "afterMeetingCount": "Après",
-        "afterMeetingCountInput": "Comptage des réunions",
-        "afterMeetingCountInputUnit": "Réunions",
-        "afterMeetingCountLong_one": "Termine après {{count}} réunions",
-        "afterMeetingCountLong_other": "Termine après {{count}} réunions",
-        "endOfRecurringMeeting": "Fin de la réunion récurrente",
-        "invalidInput": "Entrée incorrecte",
-        "never": "Jamais",
-        "neverLong": "La réunion sera répétée pour toujours",
-        "untilDate": "En",
-        "untilDateInput": "Date à laquelle termine la réunion récurrente",
-        "untilDateInputInvalid": "Date incorrecte",
-        "untilDateInputOpenDatePicker": "Selectionnez la date à laquelle termine la réunion récurrente, la date selectionnée {{date, datetime}}",
-        "untilDateLong": "La réunion sera répétée jusqu’à {{date,datetime}}"
-      },
-      "repeatMeeting": "Répéter réunion",
-      "ruleText": {
-        "afterMeetingCount_one": "une fois",
-        "afterMeetingCount_other": "pour {{count}} fois",
-        "daily_one": "Tous day$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "daily_other": "Tous {{count}} days$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_bymonthday_one": "Chaque mois dans $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_bymonthday_other": "Chaque {{count}} mois, en $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_byweekday_one": "Mensuellement, en {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_byweekday_other": "À chaque {{count}} mois, en {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_simple_one": "Tous les month$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_simple_other": "À chaque {{count}} months$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "ordinal_ordinal_one": "{{count}}er",
-        "ordinal_ordinal_two": "{{count}}e",
-        "ordinal_ordinal_few": "{{count}}e",
-        "ordinal_ordinal_other": "{{count}}e",
-        "recurrenceEnd_count": " $t(recurrenceEditor.ruleText.afterMeetingCount, {\"count\": {{afterMeetingCount}}, \"ordinal\": false })",
-        "recurrenceEnd_never": "",
-        "recurrenceEnd_until": " jusqu’à {{ untilDate, datetime(year: 'numeric'; month: 'long'; day: 'numeric') }}",
-        "unknown": "Recurrence non soutenue",
-        "weekly_all_one": "Tous les week$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "weekly_all_other": "Tous les {{count}} weeks$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "weekly_some_one": "Par semaine, en {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "weekly_some_other": "À chaque {{count}} semaines, en {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "weekly_weekdays_one": "Tous les weekday$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "weekly_weekdays_other": "Chaque {{count}} semaines, en weekdays$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_bymonthday_one": "Tous les {{monthLabel}} en $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_bymonthday_other": "Tous les {{count}} années, en $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true }) of {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_byweekday_one": "Tous les {{monthLabel}} en {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_byweekday_other": "À chaque {{count}} année, en {{ordinalLabel}} {{byweekday}} of {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_simple_one": "Tous les year$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_simple_other": "Tous les {{count}} years$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })"
-      },
-      "weekdayLabel": "Par semaine"
-    },
-    "scheduleMeeting": {
-      "allowMessaging": "Permettre d’envoyer des messages à tous les participants",
-      "cannotRemoveOwnUser": "Vous ne pouvez pas supprimer votre utilisateur de la réunion.",
-      "description": "Description",
-      "endAt": "Termine en",
-      "hasPowerToKickUser": "Vous n’avez pas l’autorisation de supprimer ce participant.",
-      "meetingAlreadyStarted": "La réunion a déjà commencée.",
-      "participants": "Participants",
-      "startAt": "Commence en",
-      "title": "Titre (obligatoire)",
-      "titleHelperText": "Il faut un titre",
-      "typeToSearch": "Saisiez pour chercher un utilisateur...",
-      "youAreAlwaysMember": "L’organisateur va accéder toujours à la réunion."
-    },
-    "scheduleMeetingModal": {
-      "cancel": "Annuler",
-      "create": "Créer une réunion",
-      "scheduleTitle": "Programmer une réunion"
-    },
-    "setupBreakoutSessions": {
-      "description": "Description",
-      "distributeAllRoomMembers": "Distribuer tous les {{amount}} participants",
-      "endAt": "Termine en",
-      "groupNumber": "Nombre de groupes (obligatoire)",
-      "groupNumberErrorMessage": "Il n’y a pas de participants suffisants pour le nombre de groupes que.",
-      "groups": "Groupes",
-      "groupTitleDefaultValue": "Groupe {{index}}",
-      "meetingIsOver": "La réunion a déjà terminée et ne peut pas créer des séances de groupes.",
-      "notAssignedMessage": "Quelques participants ne sont pas attribués à un groupe.",
-      "notAssignedTitle": "Observation",
-      "startAt": "Commence à"
-    },
-    "setupBreakoutSessionsModal": {
-      "cancel": "Annuler",
-      "create": "Créer une séance de groupe",
-      "title": "Programmer une séance de groupe"
-    },
-    "timeDistance": {
-      "futureText": "{{duration, relativetime}}",
-      "futureTextExact": "en {{duration}}",
-      "remainingText": "Termine {{duration, relativetime}}",
-      "remainingTextExact": "Termine en {{duration}}"
-    },
-    "widgetSelectionDropdown": {
-      "allActive": "Tous les widgets disponibles sont actifs.",
-      "instructions_one": "{{selectedCount}} de {{count}} entrée sélectionnée. Utilisez les touches flèches vers la gauche et vers la droite pour surfer entre elles. Utilisez les touches flèches vers le haut et vers le bas pour sélectionner les options.",
-      "instructions_other": "{{selectedCount}} de {{count}} entrée sélectionnée. Utilisez les touches flèches vers la gauche et vers la droite pour surfer entre elles. Utilisez les touches flèches vers le haut et vers le bas pour sélectionner les options.",
-      "label": "Widgets",
-      "loading": "En chargeant...",
-      "loadingError": "Erreur en chargeant Widgets disponibles.",
-      "noWidgets": "Sans Widgets disponibles.",
-      "tagInstructions": "Utilisez le bouton Espace Arrière/Backspace pour effacer l’entrée."
+    "save": "Enregistrer",
+    "title": "Modifier réunion"
+  },
+  "editRecurringMessage": {
+    "message": "Toutes les définitionsde de la réunion récurrente sont modifiables",
+    "titleOne": "Modifier la série des réunions récurrentes"
+  },
+  "invitedMeetingList": {
+    "detail": {
+      "invitedBy": "Invité par: {{name}}"
     }
+  },
+  "invitedMeetingsList": {
+    "title": "Invitations"
+  },
+  "meetingCard": {
+    "actions": "Actions",
+    "deleteInOpenXchangeMenu": "Effacer réunion en Open-Xchange",
+    "deleteMenu": "Effacer réunion",
+    "durationSubheader_default": "{{startDate, datetime}} – {{endDate, datetime}}",
+    "durationSubheader_recurring": "$t(meetingCard.durationSubheader_default)<0>. Récurrence: {{recurrence}}</0>",
+    "editInOpenXchangeMenu": "Modifier réunion en Open-Xchange",
+    "editMenu": "Modifier réunion",
+    "editParticipants": {
+      "buttonTitle": "Montrer participants",
+      "membership_invite": "Invité",
+      "membership_join": "Accepté",
+      "menuTitle": "Participants"
+    },
+    "meetingRoomWillBeDeleted": "La salle de réunion va être supprimée automatiquement {{remainingTime, relativetime}}.",
+    "meetingRoomWillBeDeletedSoon": "La salle de réunion va être supprimée  bientôt automatiquement.",
+    "moreSettings": "Plus configurations",
+    "recurrenceTooltip": "Récurrences: {{recurrence}}",
+    "share": {
+      "buttonTitle": "Partager réunion",
+      "dialInCopyNumber": "Nombre d’accès",
+      "dialInCopyPin": "PIN d’accès",
+      "dialInDescription": "Utilisez l´information suivante pour accèder à la conférence à partir du téléphone portable:",
+      "dialInTitle": "Inviter autres personnes",
+      "downloadIcsFile": "Transférer fichier ICS",
+      "emailCopyMessage": "Message",
+      "emailDescription": "Utilisez l’information suivante pour partager la conférence, par exemple, par email:",
+      "emailTitle": "Partager l’invitation pour la réunion",
+      "icsDescription": "Transférer la réunion en format iCalendar et addicionner à l’application de calendrier:",
+      "icsTitle": "Transférer le fichier de calendrier",
+      "linkCopyMeetingLink": "Lien pour la réunion",
+      "linkDescription": "Utilisez le lien suivant pour accèder à la réunion:",
+      "linkTitle": "Partagez le lien pour la salle de réunion",
+      "menuTitle": "Partager réunion",
+      "message": "{{title}}\n\n📅 {{date, daterange}}\n$t(meetingCard.share.messageRecurrence, {\"context\": \"{{recurrenceContext}}\" })\n$t(meetingCard.share.messageDescription, {\"context\": \"{{descriptionContext}}\" })\n__________________________\nRoom: {{link}}\n$t(meetingCard.share.messageDialIn, {\"context\": \"{{dialInContext}}\" })",
+      "messageDescription_none": "",
+      "messageDescription_present": "{{description}}\n",
+      "messageDialIn_none": "",
+      "messageDialIn_nopin": "Nombre d’accès: {{dialInNumber}}\nDial-In Pin: Pin not required\n",
+      "messageDialIn_pin": "Nombre d’accès: {{dialInNumber}}\nDial-In Pin: {{dialInPin}}\n",
+      "messageRecurrence_none": "",
+      "messageRecurrence_present": "🔁 Récurrence: {{recurrence}}\n",
+      "shareByMail": "Partager par courriel",
+      "shareDialInNumber": "Partager le nombre d’accès",
+      "shareDialInNumberError": "Erreur en chargeant les informations d’accès.",
+      "shareDialInNumberNotPresent": "Sans information d’accès disponible",
+      "shareLink": "Partager le lien de la réunion",
+      "warningRecurringMeetingDialInNumber": "C’est le nombre d’accès pour la série de réunions. En partageant ce nombre d’accès, invite les utilisateurs pour toutes les réunions de la série.",
+      "warningRecurringMeetingEmail": "C’est un email d’invitation  pour la série de réunions. En partageant ce courriel, invite les utilisateurs pour toutes les réunions de la série.",
+      "warningRecurringMeetingICalFile": "C’est un fichier       pour la série de réunions. En partageant ce fichier, invite les utilisateurs pour toutes les réunions de la série.",
+      "warningRecurringMeetingLink": "C’est un lien d’accès pour la série de réunions. En partageant ce lien, invite les utilisateurs pour toutes les réunions de la série."
+    },
+    "updateFailed": "S’il vous plaît, essayer à nouveau",
+    "updateFailedClose": "Fermer",
+    "updateFailedTitle": "Défaut en actualisant la réunion"
+  },
+  "meetingDetails": {
+    "content": {
+      "dateAndTime": "{{range, daterange}}",
+      "description": "Description",
+      "details": "Détails",
+      "organizer": "Organisateur",
+      "participants": "Participants",
+      "shareMeeting": {
+        "download": "Transférer",
+        "downloadIcsFile": "Transférer le fichier ICS",
+        "emailCopyMessage": "Message",
+        "emailDescription": "Utilisez l´information suivante pour partager la conférence, par exemple, par email:",
+        "emailTitle": "Partager l´invitaton pour la réunion",
+        "icsDescription": "Transférer la réunion en format iCalendar et additionner à l’aplication du calendrier:",
+        "icsTitle": "Transférer un fichier de calendrier",
+        "shareByMail": "Transférer par email",
+        "title": "Partager réunion",
+        "warningRecurringMeetingEmail": "C’est un email d’invitation pour la série de réunions. En partageant cet email, invite les utilisateurs pour toutes les réunions de la série.",
+        "warningRecurringMeetingICalFile": "C’est un fichier iCal pour la série de réunions. En partageant ce fichier, invite les utilisateurs pour toutes les réunions de la série."
+      }
+    },
+    "header": {
+      "deleteConfirmButton": "Effacer",
+      "deleteConfirmHeader": "Effacer réunion",
+      "deleteConfirmMessage": "Êtes-vous sûr que vous voulez effacer la réunion “{{title}}” en {{startTime, datetime}} et tout le contenu associé?",
+      "deleteFailed": "S’il vous plaît, essayez à nouveau.",
+      "deleteFailedTitle": "Défaut en effaçant la réunion",
+      "deleteInOpenXchangeMenu": "Effacer la réunion Open-Xchange",
+      "deleteMeetingConfirmButton": "Effacer réunion",
+      "deleteMenu": "Effacer",
+      "deleteSeriesConfirmButton": "Effacer série",
+      "deleteSeriesConfirmMessage": "Êtes-vous sûr que vous voulez effacer la réunion ou la série de réunions “{{title}}” en {{startTime, datetime}} et tout le contenu associé?",
+      "editInOpenXchangeMenu": "Éditer réunion en Open-Xchange",
+      "editMenu": "Éditer",
+      "join": "Accéder",
+      "joinBreakout_breakout": "Accéder"
+    }
+  },
+  "meetingHasBreakoutSessionsWarning": {
+    "message": "Si vous voulez changer l’heure du début ou fin de cette réunion, les séances de groupe ne seront pas déplacés!",
+    "title": "La réunion a déjà des séances de groupe."
+  },
+  "meetingInvitationGuard": {
+    "meetingInvitation": "S’il vous plaît, acceptez l’invitation pour la réunion  pour voir tous les détails."
+  },
+  "meetingList": {
+    "groupTitle": "{{date, datetime}}",
+    "noBreakoutSessionsScheduled": "Il n’y a pas de séances de groupe prévus qui correspondent aux filtres sélectionnés.",
+    "noMeetingsScheduled": "Il n’y a pas de réunions prévues qui correspondent aux filtres sélectionnés.",
+    "openInvitationsDetail": "S’il vous plaît, accédez à toutes les salles de réunions.",
+    "openInvitationsTitle": "Il y a des invitations ouvertes.",
+    "title": "Réunions"
+  },
+  "meetingsCalendar": {
+    "event": {
+      "startTime": "{{startTime, datetime}}",
+      "summary_default": "{{startTime, datetime}}–{{endTime, datetime}}: “{{title}}” pour {{creator}}",
+      "summary_recurring": "{{startTime, datetime}}–{{endTime, datetime}}: “{{title}}” pour {{creator}}, réunion récurrente"
+    }
+  },
+  "meetingsFilter": {
+    "filterAriaLabel": "Chercher",
+    "filterPlaceholder": "Chercher..."
+  },
+  "meetingsNavigation": {
+    "increaseWidth": "Augmenter la largeur du widget",
+    "increaseWidthToShowMore": "Augmenter la largeur du widget pour permettre plus de visualisations.",
+    "label": "Visualiser",
+    "views": {
+      "day": "Jour",
+      "list": "Liste",
+      "month": "Mois",
+      "week": "Semaine",
+      "workWeek": "Semaine ouvrable"
+    }
+  },
+  "meetingsPanel": {
+    "actionsTitle": "Actions",
+    "filtersTitle": "Filtres",
+    "messageToAllBreakoutRoom": {
+      "placeholder": "Envoyer un message...",
+      "sendFailed": "S’il vous plaît, essayez à nouveau.",
+      "sendFailedTitle": "Défaut en envoyant le message",
+      "sendLabel": "Envoyer message pour toutes les salles",
+      "sendTimeout": "La modification a été soumise avec succès et sera appliquée bientôt.",
+      "sendTimeoutTitle": "La demande a été envoyée",
+      "title": "Envoyer message pour toutes les salles de séances de groupes"
+    },
+    "scheduleBreakoutSession": "Programmer séance de groupe",
+    "scheduleMeeting": "Programmer réunion",
+    "tabTitle": "Visualisations",
+    "tabTitleInvitations": "Invitations",
+    "tabTitleMeetings": "Réunions"
+  },
+  "meetingsToolbar": {
+    "filterAriaLabel": "Chercher",
+    "filterPlaceholder": "Chercher...",
+    "next": {
+      "day": "Jour suivant",
+      "month": "Mois suivant",
+      "period": "Période suivante",
+      "week": "Semaine suivante",
+      "workweek": "Prochaine semaine ouvrable"
+    },
+    "previous": {
+      "day": "Jour précédent",
+      "month": "Mois précédent",
+      "period": "Période précédente",
+      "week": "Semaine précédente",
+      "workweek": "Semaine ouvrable précédente"
+    },
+    "today": "Aujourd’hui"
+  },
+  "meetingViewEditMeeting": {
+    "breakoutSessionIsOver": "La séance de groupe a déjà terminé et ne peut pas être changé.",
+    "meetingIsOver": "La réunion a déjà terminé et ne peut pas être changé."
+  },
+  "memberSelectionDropdown": {
+    "instructions_one": "{{selectedCount}} de {{count}} entrée sélectionnée. Utilisez les touches flèches vers la gauche et vers la droite pour surfer entre elles. Utilisez les touches flèches vers le haut et vers le bas pour accéder aux options disponibles.",
+    "instructions_other": "{{selectedCount}} de {{count}} entrée sélectionnée. Utilisez les touches flèches vers la gauche et vers la droite pour surfer entre elles. Utilisez les touches flèches vers le haut et vers le bas pour accéder aux options disponibles.",
+    "loadingError": "Erreur lors du chargement des utilisateurs disponibles.",
+    "loadingUsers": "En chargeant utilisateurs...",
+    "noMembers": "Sans membres disponibles.",
+    "tagInstructions": "Utilisez le bouton Espace Arrière/Backspace pour effacer l’entrée."
+  },
+  "openMeetingRoomButton": {
+    "openMeetingRoom": "Ouvrir la salle de réunion",
+    "openMeetingRoom_breakout": "Ouvrir la salle des séances de groupe"
+  },
+  "recurrenceEditor": {
+    "custom": {
+      "frequency": {
+        "days": "Jours",
+        "months": "Mois",
+        "weeks": "Semaines",
+        "years": "Années"
+      },
+      "frequencyLabel": "Répéter",
+      "intervalLabel": "{{frequencyLabel}} jusqu’à ce que cette réunion soit répétée",
+      "invalidInput": "Entrée incorrecte",
+      "monthly": {
+        "byMonthday": "Le jour",
+        "byMonthdayLong": "La réunion sera répétée mensuellement en {{nthMonthday}}",
+        "byWeekday": "En",
+        "byWeekdayLong": "La réunion sera répétée mensuellement en {{ordinalLabel}} {{weekday}}",
+        "customRuleMode": "Règle personalisée",
+        "invalidInput": "Entrée incorrecte",
+        "monthdayInput": "Jour"
+      },
+      "repeatEvery": "Répéter à chaque",
+      "title": "Réunion récurrente personalisée",
+      "weekly": {
+        "repeatOnWeekday": "Répéter dans le jour de la semaine"
+      },
+      "yearly": {
+        "byMonthday": "Le jour",
+        "byMonthdayLong": "La réunion sera répétée annuellement en {{nthMonthday}} {{month}}",
+        "byWeekday": "Dans le",
+        "byWeekdayLong": "La réunion sera répétée annuellement en {{ordinalLabel}} {{weekday}} de {{month}}",
+        "byWeekdayOf": "de",
+        "customRuleMode": "Règle personnalisée",
+        "invalidInput": "Entrée incorrecte",
+        "monthdayInput": "Jour"
+      }
+    },
+    "monthLabel": "Mois",
+    "ordinalLabel": "Ordinal",
+    "ordinals": {
+      "first": "premier",
+      "fourth": "quatrième",
+      "last": "dernier",
+      "second": "deuxième",
+      "third": "troisième"
+    },
+    "recurrencePreset": {
+      "custom": "Personnalisée",
+      "daily": "Tous les jours",
+      "mondayToFriday": "De lundi à vendredi",
+      "monthly": "Mensuellement",
+      "once": "Sans répétition",
+      "weekly": "Par semaine",
+      "yearly": "Annuellement"
+    },
+    "recurringMeetingEnd": {
+      "afterMeetingCount": "Après",
+      "afterMeetingCountInput": "Comptage des réunions",
+      "afterMeetingCountInputUnit": "Réunions",
+      "afterMeetingCountLong_one": "Termine après {{count}} réunions",
+      "afterMeetingCountLong_other": "Termine après {{count}} réunions",
+      "endOfRecurringMeeting": "Fin de la réunion récurrente",
+      "invalidInput": "Entrée incorrecte",
+      "never": "Jamais",
+      "neverLong": "La réunion sera répétée pour toujours",
+      "untilDate": "En",
+      "untilDateInput": "Date à laquelle termine la réunion récurrente",
+      "untilDateInputInvalid": "Date incorrecte",
+      "untilDateInputOpenDatePicker": "Selectionnez la date à laquelle termine la réunion récurrente, la date selectionnée {{date, datetime}}",
+      "untilDateLong": "La réunion sera répétée jusqu’à {{date,datetime}}"
+    },
+    "repeatMeeting": "Répéter réunion",
+    "ruleText": {
+      "afterMeetingCount_one": "une fois",
+      "afterMeetingCount_other": "pour {{count}} fois",
+      "daily_one": "Tous day$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "daily_other": "Tous {{count}} days$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_bymonthday_one": "Chaque mois dans $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_bymonthday_other": "Chaque {{count}} mois, en $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_byweekday_one": "Mensuellement, en {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_byweekday_other": "À chaque {{count}} mois, en {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_simple_one": "Tous les month$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_simple_other": "À chaque {{count}} months$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "ordinal_ordinal_one": "{{count}}er",
+      "ordinal_ordinal_two": "{{count}}e",
+      "ordinal_ordinal_few": "{{count}}e",
+      "ordinal_ordinal_other": "{{count}}e",
+      "recurrenceEnd_count": " $t(recurrenceEditor.ruleText.afterMeetingCount, {\"count\": {{afterMeetingCount}}, \"ordinal\": false })",
+      "recurrenceEnd_never": "",
+      "recurrenceEnd_until": " jusqu’à {{ untilDate, datetime(year: 'numeric'; month: 'long'; day: 'numeric') }}",
+      "unknown": "Recurrence non soutenue",
+      "weekly_all_one": "Tous les week$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_all_other": "Tous les {{count}} weeks$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_some_one": "Par semaine, en {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_some_other": "À chaque {{count}} semaines, en {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_weekdays_one": "Tous les weekday$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_weekdays_other": "Chaque {{count}} semaines, en weekdays$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_bymonthday_one": "Tous les {{monthLabel}} en $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_bymonthday_other": "Tous les {{count}} années, en $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true }) of {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_byweekday_one": "Tous les {{monthLabel}} en {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_byweekday_other": "À chaque {{count}} année, en {{ordinalLabel}} {{byweekday}} of {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_simple_one": "Tous les year$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_simple_other": "Tous les {{count}} years$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })"
+    },
+    "weekdayLabel": "Par semaine"
+  },
+  "scheduleMeeting": {
+    "allowMessaging": "Permettre d’envoyer des messages à tous les participants",
+    "cannotRemoveOwnUser": "Vous ne pouvez pas supprimer votre utilisateur de la réunion.",
+    "description": "Description",
+    "endAt": "Termine en",
+    "hasPowerToKickUser": "Vous n’avez pas l’autorisation de supprimer ce participant.",
+    "meetingAlreadyStarted": "La réunion a déjà commencée.",
+    "participants": "Participants",
+    "startAt": "Commence en",
+    "title": "Titre (obligatoire)",
+    "titleHelperText": "Il faut un titre",
+    "typeToSearch": "Saisiez pour chercher un utilisateur...",
+    "youAreAlwaysMember": "L’organisateur va accéder toujours à la réunion."
+  },
+  "scheduleMeetingModal": {
+    "cancel": "Annuler",
+    "create": "Créer une réunion",
+    "scheduleTitle": "Programmer une réunion"
+  },
+  "setupBreakoutSessions": {
+    "description": "Description",
+    "distributeAllRoomMembers": "Distribuer tous les {{amount}} participants",
+    "endAt": "Termine en",
+    "groupNumber": "Nombre de groupes (obligatoire)",
+    "groupNumberErrorMessage": "Il n’y a pas de participants suffisants pour le nombre de groupes que.",
+    "groups": "Groupes",
+    "groupTitleDefaultValue": "Groupe {{index}}",
+    "meetingIsOver": "La réunion a déjà terminée et ne peut pas créer des séances de groupes.",
+    "notAssignedMessage": "Quelques participants ne sont pas attribués à un groupe.",
+    "notAssignedTitle": "Observation",
+    "startAt": "Commence à"
+  },
+  "setupBreakoutSessionsModal": {
+    "cancel": "Annuler",
+    "create": "Créer une séance de groupe",
+    "title": "Programmer une séance de groupe"
+  },
+  "timeDistance": {
+    "futureText": "{{duration, relativetime}}",
+    "futureTextExact": "en {{duration}}",
+    "remainingText": "Termine {{duration, relativetime}}",
+    "remainingTextExact": "Termine en {{duration}}"
+  },
+  "widgetSelectionDropdown": {
+    "allActive": "Tous les widgets disponibles sont actifs.",
+    "instructions_one": "{{selectedCount}} de {{count}} entrée sélectionnée. Utilisez les touches flèches vers la gauche et vers la droite pour surfer entre elles. Utilisez les touches flèches vers le haut et vers le bas pour sélectionner les options.",
+    "instructions_other": "{{selectedCount}} de {{count}} entrée sélectionnée. Utilisez les touches flèches vers la gauche et vers la droite pour surfer entre elles. Utilisez les touches flèches vers le haut et vers le bas pour sélectionner les options.",
+    "label": "Widgets",
+    "loading": "En chargeant...",
+    "loadingError": "Erreur en chargeant Widgets disponibles.",
+    "noWidgets": "Sans Widgets disponibles.",
+    "tagInstructions": "Utilisez le bouton Espace Arrière/Backspace pour effacer l’entrée."
   }
-  
+}

--- a/matrix-meetings-widget/public/locales/fr/translation.json
+++ b/matrix-meetings-widget/public/locales/fr/translation.json
@@ -1,0 +1,418 @@
+{
+    "breakoutSessionGroup": {
+      "groupTitle": "Nom du groupe (obligatoire)",
+      "groupTitleHelperText": "Il faut un nom pour le groupe",
+      "selectUser": "Sélectionner participants",
+      "youAreAlwaysMember": "L’organisateur va accéder à toutes les séances de groupes."
+    },
+    "calendarDayPicker": {
+      "chooseDate": "Sélectionnez la date, la date sélectionnée est {{date, datetime}}",
+      "label": "{{date, datetime}}"
+    },
+    "calendarMonthPicker": {
+      "chooseMonth": "Sélectionnez le mois, le mois sélectionné est {{date, datetime}}",
+      "label": "{{date, datetime}}"
+    },
+    "calendarWeekPicker": {
+      "chooseWeek": "Sélectionnez la semaine, la semaine sélectionnée est {{range, daterange}}",
+      "label": "{{range, daterange}}"
+    },
+    "calendarWorkWeekPicker": {
+      "chooseWorkWeek": "Sélectionnez la semaine de travail, la semaine de travail sélectionnée est {{range, daterange}}",
+      "label": "{{range, daterange}}"
+    },
+    "cancel": "Annuler",
+    "close": "Fermer",
+    "cockpitPanel": {
+      "toParentRoom": "Rentrer dans la salle des parents"
+    },
+    "copyableTextButton": {
+      "copy-to-clipboard": "Copier pour la presse-papiers"
+    },
+    "dateRangePicker": {
+      "chooseDate": "Sélectionnez une plage de dates, la plage de dates sélectionnée est {{range, daterange}}",
+      "dateRange": "{{range, daterange}}"
+    },
+    "dateTimePickers": {
+      "endDate": "Date de fin",
+      "endTime": "Heure de la fin",
+      "error": {
+        "breakoutSessionInvalidEndTime": "Les séances de groupe doivent terminer entre {{minDate, datetime}} et {{maxDate, datetime}}.",
+        "breakoutSessionInvalidStartTime": "Les séances de groupe doivent commencer entre {{minDate, datetime}} et {{maxDate, datetime}}.",
+        "breakoutSessionStartBeforeEnd": "La date et l’heure des séances de groupe doivent être antérieures à la date et à l’heure de la fin.",
+        "meetingStartBeforeEnd": "La date et l’heure de la réunion doivent être antérieures à la date et à l’heure de la fin.",
+        "meetingStartTooEarly": "La date et l’heure de la réunion doivent être postérieures à la date et à l’heure actuelles."
+      },
+      "invalidEndDate": "Date incorrecte",
+      "invalidEndTime": "Heure incorrecte",
+      "invalidStartDate": "Date incorrecte",
+      "invalidStartTime": "Heure incorrecte",
+      "openEndDatePicker": "Sélectionnez la date de fin, la date sélectionnée est {{date, datetime}}",
+      "openEndTimePicker": "Sélectionnez l’heure de fin, l’heure sélectionnée est  {{date, datetime}}",
+      "openStartDatePicker": "Sélectionnez la date de début, la date sélectionnée est {{date, datetime}}",
+      "openStartTimePicker": "Sélectionnez l´heure de début, l´heure sélectionnée est {{date, datetime}}",
+      "startDate": "Date de début",
+      "startTime": "Heure de début"
+    },
+    "editMeetingModal": {
+      "cancel": "Annuler",
+      "save": "Enregistrer",
+      "title": "Modifier réunion"
+    },
+    "editRecurringMessage": {
+      "message": "Toutes les définitionsde de la réunion récurrente sont modifiables",
+      "titleOne": "Modifier la série des réunions récurrentes"
+    },
+    "invitedMeetingList": {
+      "detail": {
+        "invitedBy": "Invité par: {{name}}"
+      }
+    },
+    "invitedMeetingsList": {
+      "title": "Invitations"
+    },
+    "meetingCard": {
+      "actions": "Actions",
+      "deleteInOpenXchangeMenu": "Effacer réunion en Open-Xchange",
+      "deleteMenu": "Effacer réunion",
+      "durationSubheader_default": "{{startDate, datetime}} – {{endDate, datetime}}",
+      "durationSubheader_recurring": "$t(meetingCard.durationSubheader_default)<0>. Récurrence: {{recurrence}}</0>",
+      "editInOpenXchangeMenu": "Modifier réunion en Open-Xchange",
+      "editMenu": "Modifier réunion",
+      "editParticipants": {
+        "buttonTitle": "Montrer participants",
+        "membership_invite": "Invité",
+        "membership_join": "Accepté",
+        "menuTitle": "Participants"
+      },
+      "meetingRoomWillBeDeleted": "La salle de réunion va être supprimée automatiquement {{remainingTime, relativetime}}.",
+      "meetingRoomWillBeDeletedSoon": "La salle de réunion va être supprimée  bientôt automatiquement.",
+      "moreSettings": "Plus configurations",
+      "recurrenceTooltip": "Récurrences: {{recurrence}}",
+      "share": {
+        "buttonTitle": "Partager réunion",
+        "dialInCopyNumber": "Nombre d’accès",
+        "dialInCopyPin": "PIN d’accès",
+        "dialInDescription": "Utilisez l´information suivante pour accèder à la conférence à partir du téléphone portable:",
+        "dialInTitle": "Inviter autres personnes",
+        "downloadIcsFile": "Transférer fichier ICS",
+        "emailCopyMessage": "Message",
+        "emailDescription": "Utilisez l’information suivante pour partager la conférence, par exemple, par email:",
+        "emailTitle": "Partager l’invitation pour la réunion",
+        "icsDescription": "Transférer la réunion en format iCalendar et addicionner à l’application de calendrier:",
+        "icsTitle": "Transférer le fichier de calendrier",
+        "linkCopyMeetingLink": "Lien pour la réunion",
+        "linkDescription": "Utilisez le lien suivant pour accèder à la réunion:",
+        "linkTitle": "Partagez le lien pour la salle de réunion",
+        "menuTitle": "Partager réunion",
+        "message": "{{title}}\n\n📅 {{date, daterange}}\n$t(meetingCard.share.messageRecurrence, {\"context\": \"{{recurrenceContext}}\" })\n$t(meetingCard.share.messageDescription, {\"context\": \"{{descriptionContext}}\" })\n__________________________\nRoom: {{link}}\n$t(meetingCard.share.messageDialIn, {\"context\": \"{{dialInContext}}\" })",
+        "messageDescription_none": "",
+        "messageDescription_present": "{{description}}\n",
+        "messageDialIn_none": "",
+        "messageDialIn_nopin": "Nombre d’accès: {{dialInNumber}}\nDial-In Pin: Pin not required\n",
+        "messageDialIn_pin": "Nombre d’accès: {{dialInNumber}}\nDial-In Pin: {{dialInPin}}\n",
+        "messageRecurrence_none": "",
+        "messageRecurrence_present": "🔁 Récurrence: {{recurrence}}\n",
+        "shareByMail": "Partager par courriel",
+        "shareDialInNumber": "Partager le nombre d’accès",
+        "shareDialInNumberError": "Erreur en chargeant les informations d’accès.",
+        "shareDialInNumberNotPresent": "Sans information d’accès disponible",
+        "shareLink": "Partager le lien de la réunion",
+        "warningRecurringMeetingDialInNumber": "C’est le nombre d’accès pour la série de réunions. En partageant ce nombre d’accès, invite les utilisateurs pour toutes les réunions de la série.",
+        "warningRecurringMeetingEmail": "C’est un email d’invitation  pour la série de réunions. En partageant ce courriel, invite les utilisateurs pour toutes les réunions de la série.",
+        "warningRecurringMeetingICalFile": "C’est un fichier       pour la série de réunions. En partageant ce fichier, invite les utilisateurs pour toutes les réunions de la série.",
+        "warningRecurringMeetingLink": "C’est un lien d’accès pour la série de réunions. En partageant ce lien, invite les utilisateurs pour toutes les réunions de la série."
+      },
+      "updateFailed": "S’il vous plaît, essayer à nouveau",
+      "updateFailedClose": "Fermer",
+      "updateFailedTitle": "Défaut en actualisant la réunion"
+    },
+    "meetingDetails": {
+      "content": {
+        "dateAndTime": "{{range, daterange}}",
+        "description": "Description",
+        "details": "Détails",
+        "organizer": "Organisateur",
+        "participants": "Participants",
+        "shareMeeting": {
+          "download": "Transférer",
+          "downloadIcsFile": "Transférer le fichier ICS",
+          "emailCopyMessage": "Message",
+          "emailDescription": "Utilisez l´information suivante pour partager la conférence, par exemple, par email:",
+          "emailTitle": "Partager l´invitaton pour la réunion",
+          "icsDescription": "Transférer la réunion en format iCalendar et additionner à l’aplication du calendrier:",
+          "icsTitle": "Transférer un fichier de calendrier",
+          "shareByMail": "Transférer par email",
+          "title": "Partager réunion",
+          "warningRecurringMeetingEmail": "C’est un email d’invitation pour la série de réunions. En partageant cet email, invite les utilisateurs pour toutes les réunions de la série.",
+          "warningRecurringMeetingICalFile": "C’est un fichier iCal pour la série de réunions. En partageant ce fichier, invite les utilisateurs pour toutes les réunions de la série."
+        }
+      },
+      "header": {
+        "deleteConfirmButton": "Effacer",
+        "deleteConfirmHeader": "Effacer réunion",
+        "deleteConfirmMessage": "Êtes-vous sûr que vous voulez effacer la réunion “{{title}}” en {{startTime, datetime}} et tout le contenu associé?",
+        "deleteFailed": "S’il vous plaît, essayez à nouveau.",
+        "deleteFailedTitle": "Défaut en effaçant la réunion",
+        "deleteInOpenXchangeMenu": "Effacer la réunion Open-Xchange",
+        "deleteMeetingConfirmButton": "Effacer réunion",
+        "deleteMenu": "Effacer",
+        "deleteSeriesConfirmButton": "Effacer série",
+        "deleteSeriesConfirmMessage": "Êtes-vous sûr que vous voulez effacer la réunion ou la série de réunions “{{title}}” en {{startTime, datetime}} et tout le contenu associé?",
+        "editInOpenXchangeMenu": "Éditer réunion en Open-Xchange",
+        "editMenu": "Éditer",
+        "join": "Accéder",
+        "joinBreakout_breakout": "Accéder"
+      }
+    },
+    "meetingHasBreakoutSessionsWarning": {
+      "message": "Si vous voulez changer l’heure du début ou fin de cette réunion, les séances de groupe ne seront pas déplacés!",
+      "title": "La réunion a déjà des séances de groupe."
+    },
+    "meetingInvitationGuard": {
+      "meetingInvitation": "S’il vous plaît, acceptez l’invitation pour la réunion  pour voir tous les détails."
+    },
+    "meetingList": {
+      "groupTitle": "{{date, datetime}}",
+      "noBreakoutSessionsScheduled": "Il n’y a pas de séances de groupe prévus qui correspondent aux filtres sélectionnés.",
+      "noMeetingsScheduled": "Il n’y a pas de réunions prévues qui correspondent aux filtres sélectionnés.",
+      "openInvitationsDetail": "S’il vous plaît, accédez à toutes les salles de réunions.",
+      "openInvitationsTitle": "Il y a des invitations ouvertes.",
+      "title": "Réunions"
+    },
+    "meetingsCalendar": {
+      "event": {
+        "startTime": "{{startTime, datetime}}",
+        "summary_default": "{{startTime, datetime}}–{{endTime, datetime}}: “{{title}}” pour {{creator}}",
+        "summary_recurring": "{{startTime, datetime}}–{{endTime, datetime}}: “{{title}}” pour {{creator}}, réunion récurrente"
+      }
+    },
+    "meetingsFilter": {
+      "filterAriaLabel": "Chercher",
+      "filterPlaceholder": "Chercher..."
+    },
+    "meetingsNavigation": {
+      "increaseWidth": "Augmenter la largeur du widget",
+      "increaseWidthToShowMore": "Augmenter la largeur du widget pour permettre plus de visualisations.",
+      "label": "Visualiser",
+      "views": {
+        "day": "Jour",
+        "list": "Liste",
+        "month": "Mois",
+        "week": "Semaine",
+        "workWeek": "Semaine ouvrable"
+      }
+    },
+    "meetingsPanel": {
+      "actionsTitle": "Actions",
+      "filtersTitle": "Filtres",
+      "messageToAllBreakoutRoom": {
+        "placeholder": "Envoyer un message...",
+        "sendFailed": "S’il vous plaît, essayez à nouveau.",
+        "sendFailedTitle": "Défaut en envoyant le message",
+        "sendLabel": "Envoyer message pour toutes les salles",
+        "sendTimeout": "La modification a été soumise avec succès et sera appliquée bientôt.",
+        "sendTimeoutTitle": "La demande a été envoyée",
+        "title": "Envoyer message pour toutes les salles de séances de groupes"
+      },
+      "scheduleBreakoutSession": "Programmer séance de groupe",
+      "scheduleMeeting": "Programmer réunion",
+      "tabTitle": "Visualisations",
+      "tabTitleInvitations": "Invitations",
+      "tabTitleMeetings": "Réunions"
+    },
+    "meetingsToolbar": {
+      "filterAriaLabel": "Chercher",
+      "filterPlaceholder": "Chercher...",
+      "next": {
+        "day": "Jour suivant",
+        "month": "Mois suivant",
+        "period": "Période suivante",
+        "week": "Semaine suivante",
+        "workweek": "Prochaine semaine ouvrable"
+      },
+      "previous": {
+        "day": "Jour précédent",
+        "month": "Mois précédent",
+        "period": "Période précédente",
+        "week": "Semaine précédente",
+        "workweek": "Semaine ouvrable précédente"
+      },
+      "today": "Aujourd’hui"
+    },
+    "meetingViewEditMeeting": {
+      "breakoutSessionIsOver": "La séance de groupe a déjà terminé et ne peut pas être changé.",
+      "meetingIsOver": "La réunion a déjà terminé et ne peut pas être changé."
+    },
+    "memberSelectionDropdown": {
+      "instructions_one": "{{selectedCount}} de {{count}} entrée sélectionnée. Utilisez les touches flèches vers la gauche et vers la droite pour surfer entre elles. Utilisez les touches flèches vers le haut et vers le bas pour accéder aux options disponibles.",
+      "instructions_other": "{{selectedCount}} de {{count}} entrée sélectionnée. Utilisez les touches flèches vers la gauche et vers la droite pour surfer entre elles. Utilisez les touches flèches vers le haut et vers le bas pour accéder aux options disponibles.",
+      "loadingError": "Erreur lors du chargement des utilisateurs disponibles.",
+      "loadingUsers": "En chargeant utilisateurs...",
+      "noMembers": "Sans membres disponibles.",
+      "tagInstructions": "Utilisez le bouton Espace Arrière/Backspace pour effacer l’entrée."
+    },
+    "openMeetingRoomButton": {
+      "openMeetingRoom": "Ouvrir la salle de réunion",
+      "openMeetingRoom_breakout": "Ouvrir la salle des séances de groupe"
+    },
+    "recurrenceEditor": {
+      "custom": {
+        "frequency": {
+          "days": "Jours",
+          "months": "Mois",
+          "weeks": "Semaines",
+          "years": "Années"
+        },
+        "frequencyLabel": "Répéter",
+        "intervalLabel": "{{frequencyLabel}} jusqu’à ce que cette réunion soit répétée",
+        "invalidInput": "Entrée incorrecte",
+        "monthly": {
+          "byMonthday": "Le jour",
+          "byMonthdayLong": "La réunion sera répétée mensuellement en {{nthMonthday}}",
+          "byWeekday": "En",
+          "byWeekdayLong": "La réunion sera répétée mensuellement en {{ordinalLabel}} {{weekday}}",
+          "customRuleMode": "Règle personalisée",
+          "invalidInput": "Entrée incorrecte",
+          "monthdayInput": "Jour"
+        },
+        "repeatEvery": "Répéter à chaque",
+        "title": "Réunion récurrente personalisée",
+        "weekly": {
+          "repeatOnWeekday": "Répéter dans le jour de la semaine"
+        },
+        "yearly": {
+          "byMonthday": "Le jour",
+          "byMonthdayLong": "La réunion sera répétée annuellement en {{nthMonthday}} {{month}}",
+          "byWeekday": "Dans le",
+          "byWeekdayLong": "La réunion sera répétée annuellement en {{ordinalLabel}} {{weekday}} de {{month}}",
+          "byWeekdayOf": "de",
+          "customRuleMode": "Règle personnalisée",
+          "invalidInput": "Entrée incorrecte",
+          "monthdayInput": "Jour"
+        }
+      },
+      "monthLabel": "Mois",
+      "ordinalLabel": "Ordinal",
+      "ordinals": {
+        "first": "premier",
+        "fourth": "quatrième",
+        "last": "dernier",
+        "second": "deuxième",
+        "third": "troisième"
+      },
+      "recurrencePreset": {
+        "custom": "Personnalisée",
+        "daily": "Tous les jours",
+        "mondayToFriday": "De lundi à vendredi",
+        "monthly": "Mensuellement",
+        "once": "Sans répétition",
+        "weekly": "Par semaine",
+        "yearly": "Annuellement"
+      },
+      "recurringMeetingEnd": {
+        "afterMeetingCount": "Après",
+        "afterMeetingCountInput": "Comptage des réunions",
+        "afterMeetingCountInputUnit": "Réunions",
+        "afterMeetingCountLong_one": "Termine après {{count}} réunions",
+        "afterMeetingCountLong_other": "Termine après {{count}} réunions",
+        "endOfRecurringMeeting": "Fin de la réunion récurrente",
+        "invalidInput": "Entrée incorrecte",
+        "never": "Jamais",
+        "neverLong": "La réunion sera répétée pour toujours",
+        "untilDate": "En",
+        "untilDateInput": "Date à laquelle termine la réunion récurrente",
+        "untilDateInputInvalid": "Date incorrecte",
+        "untilDateInputOpenDatePicker": "Selectionnez la date à laquelle termine la réunion récurrente, la date selectionnée {{date, datetime}}",
+        "untilDateLong": "La réunion sera répétée jusqu’à {{date,datetime}}"
+      },
+      "repeatMeeting": "Répéter réunion",
+      "ruleText": {
+        "afterMeetingCount_one": "une fois",
+        "afterMeetingCount_other": "pour {{count}} fois",
+        "daily_one": "Tous day$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "daily_other": "Tous {{count}} days$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_bymonthday_one": "Chaque mois dans $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_bymonthday_other": "Chaque {{count}} mois, en $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_byweekday_one": "Mensuellement, en {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_byweekday_other": "À chaque {{count}} mois, en {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_simple_one": "Tous les month$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_simple_other": "À chaque {{count}} months$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "ordinal_ordinal_one": "{{count}}er",
+        "ordinal_ordinal_two": "{{count}}e",
+        "ordinal_ordinal_few": "{{count}}e",
+        "ordinal_ordinal_other": "{{count}}e",
+        "recurrenceEnd_count": " $t(recurrenceEditor.ruleText.afterMeetingCount, {\"count\": {{afterMeetingCount}}, \"ordinal\": false })",
+        "recurrenceEnd_never": "",
+        "recurrenceEnd_until": " jusqu’à {{ untilDate, datetime(year: 'numeric'; month: 'long'; day: 'numeric') }}",
+        "unknown": "Recurrence non soutenue",
+        "weekly_all_one": "Tous les week$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "weekly_all_other": "Tous les {{count}} weeks$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "weekly_some_one": "Par semaine, en {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "weekly_some_other": "À chaque {{count}} semaines, en {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "weekly_weekdays_one": "Tous les weekday$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "weekly_weekdays_other": "Chaque {{count}} semaines, en weekdays$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_bymonthday_one": "Tous les {{monthLabel}} en $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_bymonthday_other": "Tous les {{count}} années, en $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true }) of {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_byweekday_one": "Tous les {{monthLabel}} en {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_byweekday_other": "À chaque {{count}} année, en {{ordinalLabel}} {{byweekday}} of {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_simple_one": "Tous les year$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_simple_other": "Tous les {{count}} years$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })"
+      },
+      "weekdayLabel": "Par semaine"
+    },
+    "scheduleMeeting": {
+      "allowMessaging": "Permettre d’envoyer des messages à tous les participants",
+      "cannotRemoveOwnUser": "Vous ne pouvez pas supprimer votre utilisateur de la réunion.",
+      "description": "Description",
+      "endAt": "Termine en",
+      "hasPowerToKickUser": "Vous n’avez pas l’autorisation de supprimer ce participant.",
+      "meetingAlreadyStarted": "La réunion a déjà commencée.",
+      "participants": "Participants",
+      "startAt": "Commence en",
+      "title": "Titre (obligatoire)",
+      "titleHelperText": "Il faut un titre",
+      "typeToSearch": "Saisiez pour chercher un utilisateur...",
+      "youAreAlwaysMember": "L’organisateur va accéder toujours à la réunion."
+    },
+    "scheduleMeetingModal": {
+      "cancel": "Annuler",
+      "create": "Créer une réunion",
+      "scheduleTitle": "Programmer une réunion"
+    },
+    "setupBreakoutSessions": {
+      "description": "Description",
+      "distributeAllRoomMembers": "Distribuer tous les {{amount}} participants",
+      "endAt": "Termine en",
+      "groupNumber": "Nombre de groupes (obligatoire)",
+      "groupNumberErrorMessage": "Il n’y a pas de participants suffisants pour le nombre de groupes que.",
+      "groups": "Groupes",
+      "groupTitleDefaultValue": "Groupe {{index}}",
+      "meetingIsOver": "La réunion a déjà terminée et ne peut pas créer des séances de groupes.",
+      "notAssignedMessage": "Quelques participants ne sont pas attribués à un groupe.",
+      "notAssignedTitle": "Observation",
+      "startAt": "Commence à"
+    },
+    "setupBreakoutSessionsModal": {
+      "cancel": "Annuler",
+      "create": "Créer une séance de groupe",
+      "title": "Programmer une séance de groupe"
+    },
+    "timeDistance": {
+      "futureText": "{{duration, relativetime}}",
+      "futureTextExact": "en {{duration}}",
+      "remainingText": "Termine {{duration, relativetime}}",
+      "remainingTextExact": "Termine en {{duration}}"
+    },
+    "widgetSelectionDropdown": {
+      "allActive": "Tous les widgets disponibles sont actifs.",
+      "instructions_one": "{{selectedCount}} de {{count}} entrée sélectionnée. Utilisez les touches flèches vers la gauche et vers la droite pour surfer entre elles. Utilisez les touches flèches vers le haut et vers le bas pour sélectionner les options.",
+      "instructions_other": "{{selectedCount}} de {{count}} entrée sélectionnée. Utilisez les touches flèches vers la gauche et vers la droite pour surfer entre elles. Utilisez les touches flèches vers le haut et vers le bas pour sélectionner les options.",
+      "label": "Widgets",
+      "loading": "En chargeant...",
+      "loadingError": "Erreur en chargeant Widgets disponibles.",
+      "noWidgets": "Sans Widgets disponibles.",
+      "tagInstructions": "Utilisez le bouton Espace Arrière/Backspace pour effacer l’entrée."
+    }
+  }
+  

--- a/matrix-meetings-widget/public/locales/pt/translation.json
+++ b/matrix-meetings-widget/public/locales/pt/translation.json
@@ -1,0 +1,418 @@
+{
+    "breakoutSessionGroup": {
+      "groupTitle": "Nome do Grupo (necessário)",
+      "groupTitleHelperText": "É necessário um nome para o grupo",
+      "selectUser": "Selecionar participantes",
+      "youAreAlwaysMember": "O organizador vai aceder a todas as sessões de breakout."
+    },
+    "calendarDayPicker": {
+      "chooseDate": "Selecione a data, a data selecionada é {{date, datetime}}",
+      "label": "{{date, datetime}}"
+    },
+    "calendarMonthPicker": {
+      "chooseMonth": "Selecione o mês, o mês selecionado é {{date, datetime}}",
+      "label": "{{date, datetime}}"
+    },
+    "calendarWeekPicker": {
+      "chooseWeek": "Selecione a semana, a semana selecionada é {{range, daterange}}",
+      "label": "{{range, daterange}}"
+    },
+    "calendarWorkWeekPicker": {
+      "chooseWorkWeek": "Selecione a semana de trabalho, a semana de trabalho selecionada é {{range, daterange}}",
+      "label": "{{range, daterange}}"
+    },
+    "cancel": "Cancelar",
+    "close": "Fechar",
+    "cockpitPanel": {
+      "toParentRoom": "Voltar à sala de pais"
+    },
+    "copyableTextButton": {
+      "copy-to-clipboard": "Copiar para a área de transferência"
+    },
+    "dateRangePicker": {
+      "chooseDate": "Selecione o intervalo de datas, o intervalo selecionado é {{range, daterange}}",
+      "dateRange": "{{range, daterange}}"
+    },
+    "dateTimePickers": {
+      "endDate": "Data de fim",
+      "endTime": "Hora de fim",
+      "error": {
+        "breakoutSessionInvalidEndTime": "As sessões de Breakout devem terminar entre {{minDate, datetime}} e {{maxDate, datetime}}.",
+        "breakoutSessionInvalidStartTime": "As sessões de Breakout devem iniciar entre {{minDate, datetime}} e {{maxDate, datetime}}.",
+        "breakoutSessionStartBeforeEnd": "A data e hora das sessões de Breakout devem ser anteriores à data e hora de término.",
+        "meetingStartBeforeEnd": "A data e hora da reunião devem ser anteriores à data e hora de término.",
+        "meetingStartTooEarly": "A data e hora da reunião devem ser posteriores à data e hora atuais."
+      },
+      "invalidEndDate": "Data inválida",
+      "invalidEndTime": "Hora inválida",
+      "invalidStartDate": "Data inválida",
+      "invalidStartTime": "Hora inválida",
+      "openEndDatePicker": "Selecione a data de fim, a data selecionada é {{date, datetime}}",
+      "openEndTimePicker": "Selecione a hora de fim, a hora selecionada é {{date, datetime}}",
+      "openStartDatePicker": "Selecione a data de início, a data selecionada é {{date, datetime}}",
+      "openStartTimePicker": "Selecione a hora de início, a hora selecionada é {{date, datetime}}",
+      "startDate": "Data de início",
+      "startTime": "Hora de início"
+    },
+    "editMeetingModal": {
+      "cancel": "Cancelar",
+      "save": "Guardar",
+      "title": "Editar reunião"
+    },
+    "editRecurringMessage": {
+      "message": "Todas as definições da reunião recorrente são editáveis",
+      "titleOne": "Editar a série de reuniões recorrentes"
+    },
+    "invitedMeetingList": {
+      "detail": {
+        "invitedBy": "Convidado por: {{name}}"
+      }
+    },
+    "invitedMeetingsList": {
+      "title": "Convites"
+    },
+    "meetingCard": {
+      "actions": "Ações",
+      "deleteInOpenXchangeMenu": "Apagar reunião em Open-Xchange",
+      "deleteMenu": "Apagar reunião",
+      "durationSubheader_default": "{{startDate, datetime}} – {{endDate, datetime}}",
+      "durationSubheader_recurring": "$t(meetingCard.durationSubheader_default)<0>. Recurrence: {{recurrence}}</0>",
+      "editInOpenXchangeMenu": "Editar reunião em Open-Xchange",
+      "editMenu": "Editar reunião",
+      "editParticipants": {
+        "buttonTitle": "Mostrar participantes",
+        "membership_invite": "Convidado",
+        "membership_join": "Aceite",
+        "menuTitle": "Participantes"
+      },
+      "meetingRoomWillBeDeleted": "A sala de reunião vai ser apagada automaticamente {{remainingTime, relativetime}}.",
+      "meetingRoomWillBeDeletedSoon": "A sala de reunião vai ser apagada automaticamente em breve.",
+      "moreSettings": "Mais configurações",
+      "recurrenceTooltip": "Recorrência: {{recurrence}}",
+      "share": {
+        "buttonTitle": "Partilhar reunião",
+        "dialInCopyNumber": "Número de acesso",
+        "dialInCopyPin": "Pin de acesso",
+        "dialInDescription": "Utilize a informação seguinte para aceder à conferência através do telemóvel:",
+        "dialInTitle": "Convidar mais pessoas",
+        "downloadIcsFile": "Transferir ficheiro ICS",
+        "emailCopyMessage": "Mensagem",
+        "emailDescription": "Utilize a informação seguinte para partilhar a conferência, por exemplo, por email:",
+        "emailTitle": "Partilhar o convite para a reunião",
+        "icsDescription": "Transferir a reunião no formato iCalendar e adicionar à aplicação de calendário:",
+        "icsTitle": "Transferir o ficheiro de calendário",
+        "linkCopyMeetingLink": "Link para a reunião",
+        "linkDescription": "Utilize o link seguinte para aceder à reunião:",
+        "linkTitle": "Partilhe o link pra a sala de reunião",
+        "menuTitle": "Partilhar reunião",
+        "message": "{{title}}\n\n📅 {{date, daterange}}\n$t(meetingCard.share.messageRecurrence, {\"context\": \"{{recurrenceContext}}\" })\n$t(meetingCard.share.messageDescription, {\"context\": \"{{descriptionContext}}\" })\n__________________________\nRoom: {{link}}\n$t(meetingCard.share.messageDialIn, {\"context\": \"{{dialInContext}}\" })",
+        "messageDescription_none": "",
+        "messageDescription_present": "{{description}}\n",
+        "messageDialIn_none": "",
+        "messageDialIn_nopin": "Número de acesso: {{dialInNumber}}\nDial-In Pin: Pin not required\n",
+        "messageDialIn_pin": "Número de acesso: {{dialInNumber}}\nDial-In Pin: {{dialInPin}}\n",
+        "messageRecurrence_none": "",
+        "messageRecurrence_present": "🔁 Recorrência: {{recurrence}}\n",
+        "shareByMail": "Partilhar por email",
+        "shareDialInNumber": "Partilhar o número de acesso",
+        "shareDialInNumberError": "Erro ao carregar as informações de acesso.",
+        "shareDialInNumberNotPresent": "Sem informação de acesso disponível",
+        "shareLink": "Partilhar o link para a reunião",
+        "warningRecurringMeetingDialInNumber": "Este é um número de acesso para a série de reuniões. Ao partilhar este número de acesso, convida os utilizadores para todas as reuniões da série.",
+        "warningRecurringMeetingEmail": "Este é um email convite para a série de reuniões. Ao partilhar este email, convida os utilizadores para todas as reuniões da série.",
+        "warningRecurringMeetingICalFile": "Este é um ficheiro iCal para a série de reuniões. Ao partilhar este ficheiro, convida os utilizadores para todas as reuniões da série",
+        "warningRecurringMeetingLink": "Este é um link de acesso à série de reuniões. Ao partilhar este link, convida os utilizadores para todas as reuniões da série."
+      },
+      "updateFailed": "Por favor, tente de novo",
+      "updateFailedClose": "Fechar",
+      "updateFailedTitle": "Falha ao atualizar a reunião"
+    },
+    "meetingDetails": {
+      "content": {
+        "dateAndTime": "{{range, daterange}}",
+        "description": "Descrição",
+        "details": "Detalhes",
+        "organizer": "Organizador",
+        "participants": "Participantes",
+        "shareMeeting": {
+          "download": "Transferir",
+          "downloadIcsFile": "Transferir o ficheiro ICS",
+          "emailCopyMessage": "Mensagem",
+          "emailDescription": "Utilize a informação seguinte para partilhar a conferência, por exemplo, por email:",
+          "emailTitle": "Partilhar o convite para a reunião",
+          "icsDescription": "Transferir a reunião no formato iCalendar e adicionar à aplicação de calendário:",
+          "icsTitle": "Transferir um ficheiro de calendário",
+          "shareByMail": "Partilhar por email",
+          "title": "Partilhar reunião",
+          "warningRecurringMeetingEmail": "Este é um email convite para a série de reuniões. Ao partilhar este email, convida os utilizadores para todas as reuniões da série.",
+          "warningRecurringMeetingICalFile": "Este é um ficheiro iCal para a série de reuniões. Ao partilhar este ficheiro, convida os utilizadores para todas as reuniões da série."
+        }
+      },
+      "header": {
+        "deleteConfirmButton": "Apagar",
+        "deleteConfirmHeader": "Apagar reunião",
+        "deleteConfirmMessage": "Tem a certeza que pretende apagar a reunião “{{title}}” em {{startTime, datetime}} e todo o conteúdo relacionado com a mesma?",
+        "deleteFailed": "Por favor, tente de novo.",
+        "deleteFailedTitle": "Falha ao apagar a reunião",
+        "deleteInOpenXchangeMenu": "Apagar a reunião em Open-Xchange",
+        "deleteMeetingConfirmButton": "Apagar reunião",
+        "deleteMenu": "Apagar",
+        "deleteSeriesConfirmButton": "Apagar série",
+        "deleteSeriesConfirmMessage": "Tem a certeza que pretende apagara a reunião ou a série de reuniões “{{title}}” em {{startTime, datetime}} e todo o conteúdo relacionado com a mesma?",
+        "editInOpenXchangeMenu": "Editar reunião em Open-Xchange",
+        "editMenu": "Editar",
+        "join": "Aceder",
+        "joinBreakout_breakout": "Aceder"
+      }
+    },
+    "meetingHasBreakoutSessionsWarning": {
+      "message": "Se pretender alterar a hora de início ou fim desta reunião, as sessões de breakout não serão movidas!",
+      "title": "A reunião já tem sessões de breakout."
+    },
+    "meetingInvitationGuard": {
+      "meetingInvitation": "Por favor, aceite o convite para a reunião para ver todos os detalhes."
+    },
+    "meetingList": {
+      "groupTitle": "{{date, datetime}}",
+      "noBreakoutSessionsScheduled": "Não existem sessões de breakout agendadas que correspondam aos filtros selecionados.",
+      "noMeetingsScheduled": "Não existem reuniões agendadas que correspondam aos filtros selecionados.",
+      "openInvitationsDetail": "Por favor, aceda a todas as salas de reunião.",
+      "openInvitationsTitle": "Tem convites abertos.",
+      "title": "Reuniões"
+    },
+    "meetingsCalendar": {
+      "event": {
+        "startTime": "{{startTime, datetime}}",
+        "summary_default": "{{startTime, datetime}}–{{endTime, datetime}}: “{{title}}” por {{creator}}",
+        "summary_recurring": "{{startTime, datetime}}–{{endTime, datetime}}: “{{title}}” por {{creator}}, reunião recorrente"
+      }
+    },
+    "meetingsFilter": {
+      "filterAriaLabel": "Procurar",
+      "filterPlaceholder": "Procurar..."
+    },
+    "meetingsNavigation": {
+      "increaseWidth": "Aumentar a largura do widget",
+      "increaseWidthToShowMore": "Aumentar a largura do widget para permitir mais visualizações.",
+      "label": "Visualizar",
+      "views": {
+        "day": "Dia",
+        "list": "Lista",
+        "month": "Mês",
+        "week": "Semana",
+        "workWeek": "Semana útil"
+      }
+    },
+    "meetingsPanel": {
+      "actionsTitle": "Ações",
+      "filtersTitle": "Filtros",
+      "messageToAllBreakoutRoom": {
+        "placeholder": "Enviar uma mensagem...",
+        "sendFailed": "Por favor, tente de novo.",
+        "sendFailedTitle": "Falha ao enviar a mensagem",
+        "sendLabel": "Enviar mensagem para todas as salas",
+        "sendTimeout": "A alteração foi submetida com sucesso e será aplicada em breve.",
+        "sendTimeoutTitle": "O pedido foi enviado",
+        "title": "Enviar mensagem para todas as salas de sessões de breakout"
+      },
+      "scheduleBreakoutSession": "Agendar sessão de Breakout",
+      "scheduleMeeting": "Agendar reunião",
+      "tabTitle": "Visualizações",
+      "tabTitleInvitations": "Convites",
+      "tabTitleMeetings": "Reuniões"
+    },
+    "meetingsToolbar": {
+      "filterAriaLabel": "Procurar",
+      "filterPlaceholder": "Procurar...",
+      "next": {
+        "day": "Dia seguinte",
+        "month": "Mês seguinte",
+        "period": "Período seguinte",
+        "week": "Semana seguinte",
+        "workweek": "Próxima semana útil"
+      },
+      "previous": {
+        "day": "Dia anterior",
+        "month": "Mês anterior",
+        "period": "Período anterior",
+        "week": "Semana anterior",
+        "workweek": "Semana útil anterior"
+      },
+      "today": "Hoje"
+    },
+    "meetingViewEditMeeting": {
+      "breakoutSessionIsOver": "A sessão de breakout já terminou e não pode ser alterada.",
+      "meetingIsOver": "A reunião já terminou e não pode ser alterada."
+    },
+    "memberSelectionDropdown": {
+      "instructions_one": "{{selectedCount}} de {{count}} entrada selecionado. Utilize as teclas de setas para a esquerda e para a direita para navegar entre eles. Utilize as teclas de setas para cima e para baixo para aceder às opções disponíveis.",
+      "instructions_other": "{{selectedCount}} de {{count}} entrada selecionado. Utilize as teclas de setas para a esquerda e para a direita para navegar entre eles. Utilize as teclas de setas para cima e para baixo para aceder às opções disponíveis.",
+      "loadingError": "Erro ao carregar os utilizadores disponíveis.",
+      "loadingUsers": "Carregando utilizadores...",
+      "noMembers": "Sem membros disponíveis.",
+      "tagInstructions": "Utilize a tecla backspace para apagar a entrada."
+    },
+    "openMeetingRoomButton": {
+      "openMeetingRoom": "Abrir a sala de reunião",
+      "openMeetingRoom_breakout": "Abrir a sala de sessões de breakout"
+    },
+    "recurrenceEditor": {
+      "custom": {
+        "frequency": {
+          "days": "Dias",
+          "months": "Meses",
+          "weeks": "Semanas",
+          "years": "Anos"
+        },
+        "frequencyLabel": "Repetir",
+        "intervalLabel": "{{frequencyLabel}} até que a reunião seja repetida",
+        "invalidInput": "Entrada inválida",
+        "monthly": {
+          "byMonthday": "No dia",
+          "byMonthdayLong": "A reunião será repetida mensalmente em {{nthMonthday}}",
+          "byWeekday": "Em",
+          "byWeekdayLong": "A reunião será repetida mensalmente em {{ordinalLabel}} {{weekday}}",
+          "customRuleMode": "Regra personalizada",
+          "invalidInput": "Entrada inválida",
+          "monthdayInput": "Dia"
+        },
+        "repeatEvery": "Repetir a cada",
+        "title": "Reunião recorrente personalizada",
+        "weekly": {
+          "repeatOnWeekday": "No dia"
+        },
+        "yearly": {
+          "byMonthday": "On day",
+          "byMonthdayLong": "A reunião será repetida anualmente em {{nthMonthday}} {{month}}",
+          "byWeekday": "No",
+          "byWeekdayLong": "A reunião será repetida anualmente em {{ordinalLabel}} {{weekday}} de {{month}}",
+          "byWeekdayOf": "de",
+          "customRuleMode": "Regra personalizada",
+          "invalidInput": "Entrada inválida",
+          "monthdayInput": "Dia"
+        }
+      },
+      "monthLabel": "Mês",
+      "ordinalLabel": "Ordinal",
+      "ordinals": {
+        "first": "primeiro",
+        "fourth": "quarto",
+        "last": "último",
+        "second": "segundo",
+        "third": "terceiro"
+      },
+      "recurrencePreset": {
+        "custom": "Personalizada",
+        "daily": "Diariamente",
+        "mondayToFriday": "De segunda a sexta-feira",
+        "monthly": "Mensalmente",
+        "once": "Sem repetição",
+        "weekly": "Semanalmente",
+        "yearly": "Anualmente"
+      },
+      "recurringMeetingEnd": {
+        "afterMeetingCount": "Após",
+        "afterMeetingCountInput": "Contagem de reuniões",
+        "afterMeetingCountInputUnit": "Reuniões",
+        "afterMeetingCountLong_one": "Termina após {{count}} reuniões",
+        "afterMeetingCountLong_other": "Termina após {{count}} reuniões",
+        "endOfRecurringMeeting": "Fim da reunião recorrente",
+        "invalidInput": "Entrada inválida",
+        "never": "Nunca",
+        "neverLong": "A reunião será repetida para sempre",
+        "untilDate": "Em",
+        "untilDateInput": "Data em que a reunião recorrente termina",
+        "untilDateInputInvalid": "Data inválida",
+        "untilDateInputOpenDatePicker": "Selecione a data em que a reunião recorrente termina, a data selecionada {{date, datetime}}",
+        "untilDateLong": "A reunião será repetida até {{date,datetime}}"
+      },
+      "repeatMeeting": "Repetir reunião",
+      "ruleText": {
+        "afterMeetingCount_one": "uma vez",
+        "afterMeetingCount_other": "por {{count}} vezes",
+        "daily_one": "Todos day$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "daily_other": "Todos {{count}} days$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_bymonthday_one": "Todos os $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_bymonthday_other": "A cada {{count}} meses, em $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_byweekday_one": "Mensalmente, em {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_byweekday_other": "A cada  {{count}} meses, em {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_simple_one": "Todos os month$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "monthly_simple_other": "A cada {{count}} months$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "ordinal_ordinal_one": "{{count}}º",
+        "ordinal_ordinal_two": "{{count}}º",
+        "ordinal_ordinal_few": "{{count}}º",
+        "ordinal_ordinal_other": "{{count}}º",
+        "recurrenceEnd_count": " $t(recurrenceEditor.ruleText.afterMeetingCount, {\"count\": {{afterMeetingCount}}, \"ordinal\": false })",
+        "recurrenceEnd_never": "",
+        "recurrenceEnd_until": " até {{ untilDate, datetime(year: 'numeric'; month: 'long'; day: 'numeric') }}",
+        "unknown": "Recorrência não suportada",
+        "weekly_all_one": "Todos os week$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "weekly_all_other": "Todos os {{count}} weeks$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "weekly_some_one": "Semanalmente, em {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "weekly_some_other": "A cada {{count}} semanas, em {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "weekly_weekdays_one": "Todos os weekday$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "weekly_weekdays_other": "A cada {{count}} semanas, em weekdays$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_bymonthday_one": "Todos os {{monthLabel}} em $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_bymonthday_other": "Todos os {{count}} anos, em $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true }) of {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_byweekday_one": "Todos os {{monthLabel}} em {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_byweekday_other": "A cada {{count}} anos, em {{ordinalLabel}} {{byweekday}} of {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_simple_one": "Todos os year$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+        "yearly_simple_other": "Todos os {{count}} years$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })"
+      },
+      "weekdayLabel": "Semanalmente"
+    },
+    "scheduleMeeting": {
+      "allowMessaging": "Permitir enviar mensagens a todos os participantes",
+      "cannotRemoveOwnUser": "Não pode remover o seu utilizador da reunião.",
+      "description": "Descrição",
+      "endAt": "Termina em",
+      "hasPowerToKickUser": "Não tem permissão para remover este participante.",
+      "meetingAlreadyStarted": "A reunião já iniciou.",
+      "participants": "Participantes",
+      "startAt": "Inicia em",
+      "title": "Título (necessário)",
+      "titleHelperText": "É necessário um título",
+      "typeToSearch": "Digite para procurar um utilizador...",
+      "youAreAlwaysMember": "O organizador vai sempre aceder à reunião."
+    },
+    "scheduleMeetingModal": {
+      "cancel": "Cancelar",
+      "create": "Criar reunião",
+      "scheduleTitle": "Agendar reunião"
+    },
+    "setupBreakoutSessions": {
+      "description": "Descrição",
+      "distributeAllRoomMembers": "Distribuir todos os {{amount}} participantes",
+      "endAt": "Termina em",
+      "groupNumber": "Número de grupos (necessário)",
+      "groupNumberErrorMessage": "Não existem participantes suficientes para o número de grupos que você inscreveu.",
+      "groups": "Grupos",
+      "groupTitleDefaultValue": "Grupo {{index}}",
+      "meetingIsOver": "A reunião já terminou e não pode criar sessões de breakout.",
+      "notAssignedMessage": "Alguns participantes não estão atribuídos a um grupo.",
+      "notAssignedTitle": "Observação",
+      "startAt": "Inicia em"
+    },
+    "setupBreakoutSessionsModal": {
+      "cancel": "Cancelar",
+      "create": "Criar uma sessão de Breakout",
+      "title": "Agendar uma sessão de Breakout"
+    },
+    "timeDistance": {
+      "futureText": "{{duration, relativetime}}",
+      "futureTextExact": "em {{duration}}",
+      "remainingText": "Termina {{duration, relativetime}}",
+      "remainingTextExact": "Termina em {{duration}}"
+    },
+    "widgetSelectionDropdown": {
+      "allActive": "Todos os widgets disponíveis estão ativos.",
+      "instructions_one": "{{selectedCount}} de {{count}} entrada selecionados. Utilize as teclas de setas para a esquerda e para a direita para navegar entre elas. Utilize as teclas de setas para cima e para baixo para selecionar as opções.",
+      "instructions_other": "{{selectedCount}} de {{count}} entrada selecionados. Utilize as teclas de setas para a esquerda e para a direita para navegar entre elas. Utilize as teclas de setas para cima e para baixo para selecionar as opções.",
+      "label": "Widgets",
+      "loading": "A carregar widgets...",
+      "loadingError": "Erro ao carregar Widgets disponíveis.",
+      "noWidgets": "Sem Widgets disponíveis.",
+      "tagInstructions": "Utilize a tecla backspace para apagar a entrada."
+    }
+  }
+  

--- a/matrix-meetings-widget/public/locales/pt/translation.json
+++ b/matrix-meetings-widget/public/locales/pt/translation.json
@@ -1,418 +1,417 @@
 {
-    "breakoutSessionGroup": {
-      "groupTitle": "Nome do Grupo (necessário)",
-      "groupTitleHelperText": "É necessário um nome para o grupo",
-      "selectUser": "Selecionar participantes",
-      "youAreAlwaysMember": "O organizador vai aceder a todas as sessões de breakout."
+  "breakoutSessionGroup": {
+    "groupTitle": "Nome do Grupo (necessário)",
+    "groupTitleHelperText": "É necessário um nome para o grupo",
+    "selectUser": "Selecionar participantes",
+    "youAreAlwaysMember": "O organizador vai aceder a todas as sessões de breakout."
+  },
+  "calendarDayPicker": {
+    "chooseDate": "Selecione a data, a data selecionada é {{date, datetime}}",
+    "label": "{{date, datetime}}"
+  },
+  "calendarMonthPicker": {
+    "chooseMonth": "Selecione o mês, o mês selecionado é {{date, datetime}}",
+    "label": "{{date, datetime}}"
+  },
+  "calendarWeekPicker": {
+    "chooseWeek": "Selecione a semana, a semana selecionada é {{range, daterange}}",
+    "label": "{{range, daterange}}"
+  },
+  "calendarWorkWeekPicker": {
+    "chooseWorkWeek": "Selecione a semana de trabalho, a semana de trabalho selecionada é {{range, daterange}}",
+    "label": "{{range, daterange}}"
+  },
+  "cancel": "Cancelar",
+  "close": "Fechar",
+  "cockpitPanel": {
+    "toParentRoom": "Voltar à sala de pais"
+  },
+  "copyableTextButton": {
+    "copy-to-clipboard": "Copiar para a área de transferência"
+  },
+  "dateRangePicker": {
+    "chooseDate": "Selecione o intervalo de datas, o intervalo selecionado é {{range, daterange}}",
+    "dateRange": "{{range, daterange}}"
+  },
+  "dateTimePickers": {
+    "endDate": "Data de fim",
+    "endTime": "Hora de fim",
+    "error": {
+      "breakoutSessionInvalidEndTime": "As sessões de Breakout devem terminar entre {{minDate, datetime}} e {{maxDate, datetime}}.",
+      "breakoutSessionInvalidStartTime": "As sessões de Breakout devem iniciar entre {{minDate, datetime}} e {{maxDate, datetime}}.",
+      "breakoutSessionStartBeforeEnd": "A data e hora das sessões de Breakout devem ser anteriores à data e hora de término.",
+      "meetingStartBeforeEnd": "A data e hora da reunião devem ser anteriores à data e hora de término.",
+      "meetingStartTooEarly": "A data e hora da reunião devem ser posteriores à data e hora atuais."
     },
-    "calendarDayPicker": {
-      "chooseDate": "Selecione a data, a data selecionada é {{date, datetime}}",
-      "label": "{{date, datetime}}"
-    },
-    "calendarMonthPicker": {
-      "chooseMonth": "Selecione o mês, o mês selecionado é {{date, datetime}}",
-      "label": "{{date, datetime}}"
-    },
-    "calendarWeekPicker": {
-      "chooseWeek": "Selecione a semana, a semana selecionada é {{range, daterange}}",
-      "label": "{{range, daterange}}"
-    },
-    "calendarWorkWeekPicker": {
-      "chooseWorkWeek": "Selecione a semana de trabalho, a semana de trabalho selecionada é {{range, daterange}}",
-      "label": "{{range, daterange}}"
-    },
+    "invalidEndDate": "Data inválida",
+    "invalidEndTime": "Hora inválida",
+    "invalidStartDate": "Data inválida",
+    "invalidStartTime": "Hora inválida",
+    "openEndDatePicker": "Selecione a data de fim, a data selecionada é {{date, datetime}}",
+    "openEndTimePicker": "Selecione a hora de fim, a hora selecionada é {{date, datetime}}",
+    "openStartDatePicker": "Selecione a data de início, a data selecionada é {{date, datetime}}",
+    "openStartTimePicker": "Selecione a hora de início, a hora selecionada é {{date, datetime}}",
+    "startDate": "Data de início",
+    "startTime": "Hora de início"
+  },
+  "editMeetingModal": {
     "cancel": "Cancelar",
-    "close": "Fechar",
-    "cockpitPanel": {
-      "toParentRoom": "Voltar à sala de pais"
+    "save": "Guardar",
+    "title": "Editar reunião"
+  },
+  "editRecurringMessage": {
+    "message": "Todas as definições da reunião recorrente são editáveis",
+    "titleOne": "Editar a série de reuniões recorrentes"
+  },
+  "invitedMeetingList": {
+    "detail": {
+      "invitedBy": "Convidado por: {{name}}"
+    }
+  },
+  "invitedMeetingsList": {
+    "title": "Convites"
+  },
+  "meetingCard": {
+    "actions": "Ações",
+    "deleteInOpenXchangeMenu": "Apagar reunião em Open-Xchange",
+    "deleteMenu": "Apagar reunião",
+    "durationSubheader_default": "{{startDate, datetime}} – {{endDate, datetime}}",
+    "durationSubheader_recurring": "$t(meetingCard.durationSubheader_default)<0>. Recurrence: {{recurrence}}</0>",
+    "editInOpenXchangeMenu": "Editar reunião em Open-Xchange",
+    "editMenu": "Editar reunião",
+    "editParticipants": {
+      "buttonTitle": "Mostrar participantes",
+      "membership_invite": "Convidado",
+      "membership_join": "Aceite",
+      "menuTitle": "Participantes"
     },
-    "copyableTextButton": {
-      "copy-to-clipboard": "Copiar para a área de transferência"
+    "meetingRoomWillBeDeleted": "A sala de reunião vai ser apagada automaticamente {{remainingTime, relativetime}}.",
+    "meetingRoomWillBeDeletedSoon": "A sala de reunião vai ser apagada automaticamente em breve.",
+    "moreSettings": "Mais configurações",
+    "recurrenceTooltip": "Recorrência: {{recurrence}}",
+    "share": {
+      "buttonTitle": "Partilhar reunião",
+      "dialInCopyNumber": "Número de acesso",
+      "dialInCopyPin": "Pin de acesso",
+      "dialInDescription": "Utilize a informação seguinte para aceder à conferência através do telemóvel:",
+      "dialInTitle": "Convidar mais pessoas",
+      "downloadIcsFile": "Transferir ficheiro ICS",
+      "emailCopyMessage": "Mensagem",
+      "emailDescription": "Utilize a informação seguinte para partilhar a conferência, por exemplo, por email:",
+      "emailTitle": "Partilhar o convite para a reunião",
+      "icsDescription": "Transferir a reunião no formato iCalendar e adicionar à aplicação de calendário:",
+      "icsTitle": "Transferir o ficheiro de calendário",
+      "linkCopyMeetingLink": "Link para a reunião",
+      "linkDescription": "Utilize o link seguinte para aceder à reunião:",
+      "linkTitle": "Partilhe o link pra a sala de reunião",
+      "menuTitle": "Partilhar reunião",
+      "message": "{{title}}\n\n📅 {{date, daterange}}\n$t(meetingCard.share.messageRecurrence, {\"context\": \"{{recurrenceContext}}\" })\n$t(meetingCard.share.messageDescription, {\"context\": \"{{descriptionContext}}\" })\n__________________________\nRoom: {{link}}\n$t(meetingCard.share.messageDialIn, {\"context\": \"{{dialInContext}}\" })",
+      "messageDescription_none": "",
+      "messageDescription_present": "{{description}}\n",
+      "messageDialIn_none": "",
+      "messageDialIn_nopin": "Número de acesso: {{dialInNumber}}\nDial-In Pin: Pin not required\n",
+      "messageDialIn_pin": "Número de acesso: {{dialInNumber}}\nDial-In Pin: {{dialInPin}}\n",
+      "messageRecurrence_none": "",
+      "messageRecurrence_present": "🔁 Recorrência: {{recurrence}}\n",
+      "shareByMail": "Partilhar por email",
+      "shareDialInNumber": "Partilhar o número de acesso",
+      "shareDialInNumberError": "Erro ao carregar as informações de acesso.",
+      "shareDialInNumberNotPresent": "Sem informação de acesso disponível",
+      "shareLink": "Partilhar o link para a reunião",
+      "warningRecurringMeetingDialInNumber": "Este é um número de acesso para a série de reuniões. Ao partilhar este número de acesso, convida os utilizadores para todas as reuniões da série.",
+      "warningRecurringMeetingEmail": "Este é um email convite para a série de reuniões. Ao partilhar este email, convida os utilizadores para todas as reuniões da série.",
+      "warningRecurringMeetingICalFile": "Este é um ficheiro iCal para a série de reuniões. Ao partilhar este ficheiro, convida os utilizadores para todas as reuniões da série",
+      "warningRecurringMeetingLink": "Este é um link de acesso à série de reuniões. Ao partilhar este link, convida os utilizadores para todas as reuniões da série."
     },
-    "dateRangePicker": {
-      "chooseDate": "Selecione o intervalo de datas, o intervalo selecionado é {{range, daterange}}",
-      "dateRange": "{{range, daterange}}"
-    },
-    "dateTimePickers": {
-      "endDate": "Data de fim",
-      "endTime": "Hora de fim",
-      "error": {
-        "breakoutSessionInvalidEndTime": "As sessões de Breakout devem terminar entre {{minDate, datetime}} e {{maxDate, datetime}}.",
-        "breakoutSessionInvalidStartTime": "As sessões de Breakout devem iniciar entre {{minDate, datetime}} e {{maxDate, datetime}}.",
-        "breakoutSessionStartBeforeEnd": "A data e hora das sessões de Breakout devem ser anteriores à data e hora de término.",
-        "meetingStartBeforeEnd": "A data e hora da reunião devem ser anteriores à data e hora de término.",
-        "meetingStartTooEarly": "A data e hora da reunião devem ser posteriores à data e hora atuais."
-      },
-      "invalidEndDate": "Data inválida",
-      "invalidEndTime": "Hora inválida",
-      "invalidStartDate": "Data inválida",
-      "invalidStartTime": "Hora inválida",
-      "openEndDatePicker": "Selecione a data de fim, a data selecionada é {{date, datetime}}",
-      "openEndTimePicker": "Selecione a hora de fim, a hora selecionada é {{date, datetime}}",
-      "openStartDatePicker": "Selecione a data de início, a data selecionada é {{date, datetime}}",
-      "openStartTimePicker": "Selecione a hora de início, a hora selecionada é {{date, datetime}}",
-      "startDate": "Data de início",
-      "startTime": "Hora de início"
-    },
-    "editMeetingModal": {
-      "cancel": "Cancelar",
-      "save": "Guardar",
-      "title": "Editar reunião"
-    },
-    "editRecurringMessage": {
-      "message": "Todas as definições da reunião recorrente são editáveis",
-      "titleOne": "Editar a série de reuniões recorrentes"
-    },
-    "invitedMeetingList": {
-      "detail": {
-        "invitedBy": "Convidado por: {{name}}"
-      }
-    },
-    "invitedMeetingsList": {
-      "title": "Convites"
-    },
-    "meetingCard": {
-      "actions": "Ações",
-      "deleteInOpenXchangeMenu": "Apagar reunião em Open-Xchange",
-      "deleteMenu": "Apagar reunião",
-      "durationSubheader_default": "{{startDate, datetime}} – {{endDate, datetime}}",
-      "durationSubheader_recurring": "$t(meetingCard.durationSubheader_default)<0>. Recurrence: {{recurrence}}</0>",
-      "editInOpenXchangeMenu": "Editar reunião em Open-Xchange",
-      "editMenu": "Editar reunião",
-      "editParticipants": {
-        "buttonTitle": "Mostrar participantes",
-        "membership_invite": "Convidado",
-        "membership_join": "Aceite",
-        "menuTitle": "Participantes"
-      },
-      "meetingRoomWillBeDeleted": "A sala de reunião vai ser apagada automaticamente {{remainingTime, relativetime}}.",
-      "meetingRoomWillBeDeletedSoon": "A sala de reunião vai ser apagada automaticamente em breve.",
-      "moreSettings": "Mais configurações",
-      "recurrenceTooltip": "Recorrência: {{recurrence}}",
-      "share": {
-        "buttonTitle": "Partilhar reunião",
-        "dialInCopyNumber": "Número de acesso",
-        "dialInCopyPin": "Pin de acesso",
-        "dialInDescription": "Utilize a informação seguinte para aceder à conferência através do telemóvel:",
-        "dialInTitle": "Convidar mais pessoas",
-        "downloadIcsFile": "Transferir ficheiro ICS",
+    "updateFailed": "Por favor, tente de novo",
+    "updateFailedClose": "Fechar",
+    "updateFailedTitle": "Falha ao atualizar a reunião"
+  },
+  "meetingDetails": {
+    "content": {
+      "dateAndTime": "{{range, daterange}}",
+      "description": "Descrição",
+      "details": "Detalhes",
+      "organizer": "Organizador",
+      "participants": "Participantes",
+      "shareMeeting": {
+        "download": "Transferir",
+        "downloadIcsFile": "Transferir o ficheiro ICS",
         "emailCopyMessage": "Mensagem",
         "emailDescription": "Utilize a informação seguinte para partilhar a conferência, por exemplo, por email:",
         "emailTitle": "Partilhar o convite para a reunião",
         "icsDescription": "Transferir a reunião no formato iCalendar e adicionar à aplicação de calendário:",
-        "icsTitle": "Transferir o ficheiro de calendário",
-        "linkCopyMeetingLink": "Link para a reunião",
-        "linkDescription": "Utilize o link seguinte para aceder à reunião:",
-        "linkTitle": "Partilhe o link pra a sala de reunião",
-        "menuTitle": "Partilhar reunião",
-        "message": "{{title}}\n\n📅 {{date, daterange}}\n$t(meetingCard.share.messageRecurrence, {\"context\": \"{{recurrenceContext}}\" })\n$t(meetingCard.share.messageDescription, {\"context\": \"{{descriptionContext}}\" })\n__________________________\nRoom: {{link}}\n$t(meetingCard.share.messageDialIn, {\"context\": \"{{dialInContext}}\" })",
-        "messageDescription_none": "",
-        "messageDescription_present": "{{description}}\n",
-        "messageDialIn_none": "",
-        "messageDialIn_nopin": "Número de acesso: {{dialInNumber}}\nDial-In Pin: Pin not required\n",
-        "messageDialIn_pin": "Número de acesso: {{dialInNumber}}\nDial-In Pin: {{dialInPin}}\n",
-        "messageRecurrence_none": "",
-        "messageRecurrence_present": "🔁 Recorrência: {{recurrence}}\n",
+        "icsTitle": "Transferir um ficheiro de calendário",
         "shareByMail": "Partilhar por email",
-        "shareDialInNumber": "Partilhar o número de acesso",
-        "shareDialInNumberError": "Erro ao carregar as informações de acesso.",
-        "shareDialInNumberNotPresent": "Sem informação de acesso disponível",
-        "shareLink": "Partilhar o link para a reunião",
-        "warningRecurringMeetingDialInNumber": "Este é um número de acesso para a série de reuniões. Ao partilhar este número de acesso, convida os utilizadores para todas as reuniões da série.",
+        "title": "Partilhar reunião",
         "warningRecurringMeetingEmail": "Este é um email convite para a série de reuniões. Ao partilhar este email, convida os utilizadores para todas as reuniões da série.",
-        "warningRecurringMeetingICalFile": "Este é um ficheiro iCal para a série de reuniões. Ao partilhar este ficheiro, convida os utilizadores para todas as reuniões da série",
-        "warningRecurringMeetingLink": "Este é um link de acesso à série de reuniões. Ao partilhar este link, convida os utilizadores para todas as reuniões da série."
-      },
-      "updateFailed": "Por favor, tente de novo",
-      "updateFailedClose": "Fechar",
-      "updateFailedTitle": "Falha ao atualizar a reunião"
-    },
-    "meetingDetails": {
-      "content": {
-        "dateAndTime": "{{range, daterange}}",
-        "description": "Descrição",
-        "details": "Detalhes",
-        "organizer": "Organizador",
-        "participants": "Participantes",
-        "shareMeeting": {
-          "download": "Transferir",
-          "downloadIcsFile": "Transferir o ficheiro ICS",
-          "emailCopyMessage": "Mensagem",
-          "emailDescription": "Utilize a informação seguinte para partilhar a conferência, por exemplo, por email:",
-          "emailTitle": "Partilhar o convite para a reunião",
-          "icsDescription": "Transferir a reunião no formato iCalendar e adicionar à aplicação de calendário:",
-          "icsTitle": "Transferir um ficheiro de calendário",
-          "shareByMail": "Partilhar por email",
-          "title": "Partilhar reunião",
-          "warningRecurringMeetingEmail": "Este é um email convite para a série de reuniões. Ao partilhar este email, convida os utilizadores para todas as reuniões da série.",
-          "warningRecurringMeetingICalFile": "Este é um ficheiro iCal para a série de reuniões. Ao partilhar este ficheiro, convida os utilizadores para todas as reuniões da série."
-        }
-      },
-      "header": {
-        "deleteConfirmButton": "Apagar",
-        "deleteConfirmHeader": "Apagar reunião",
-        "deleteConfirmMessage": "Tem a certeza que pretende apagar a reunião “{{title}}” em {{startTime, datetime}} e todo o conteúdo relacionado com a mesma?",
-        "deleteFailed": "Por favor, tente de novo.",
-        "deleteFailedTitle": "Falha ao apagar a reunião",
-        "deleteInOpenXchangeMenu": "Apagar a reunião em Open-Xchange",
-        "deleteMeetingConfirmButton": "Apagar reunião",
-        "deleteMenu": "Apagar",
-        "deleteSeriesConfirmButton": "Apagar série",
-        "deleteSeriesConfirmMessage": "Tem a certeza que pretende apagara a reunião ou a série de reuniões “{{title}}” em {{startTime, datetime}} e todo o conteúdo relacionado com a mesma?",
-        "editInOpenXchangeMenu": "Editar reunião em Open-Xchange",
-        "editMenu": "Editar",
-        "join": "Aceder",
-        "joinBreakout_breakout": "Aceder"
+        "warningRecurringMeetingICalFile": "Este é um ficheiro iCal para a série de reuniões. Ao partilhar este ficheiro, convida os utilizadores para todas as reuniões da série."
       }
     },
-    "meetingHasBreakoutSessionsWarning": {
-      "message": "Se pretender alterar a hora de início ou fim desta reunião, as sessões de breakout não serão movidas!",
-      "title": "A reunião já tem sessões de breakout."
-    },
-    "meetingInvitationGuard": {
-      "meetingInvitation": "Por favor, aceite o convite para a reunião para ver todos os detalhes."
-    },
-    "meetingList": {
-      "groupTitle": "{{date, datetime}}",
-      "noBreakoutSessionsScheduled": "Não existem sessões de breakout agendadas que correspondam aos filtros selecionados.",
-      "noMeetingsScheduled": "Não existem reuniões agendadas que correspondam aos filtros selecionados.",
-      "openInvitationsDetail": "Por favor, aceda a todas as salas de reunião.",
-      "openInvitationsTitle": "Tem convites abertos.",
-      "title": "Reuniões"
-    },
-    "meetingsCalendar": {
-      "event": {
-        "startTime": "{{startTime, datetime}}",
-        "summary_default": "{{startTime, datetime}}–{{endTime, datetime}}: “{{title}}” por {{creator}}",
-        "summary_recurring": "{{startTime, datetime}}–{{endTime, datetime}}: “{{title}}” por {{creator}}, reunião recorrente"
-      }
-    },
-    "meetingsFilter": {
-      "filterAriaLabel": "Procurar",
-      "filterPlaceholder": "Procurar..."
-    },
-    "meetingsNavigation": {
-      "increaseWidth": "Aumentar a largura do widget",
-      "increaseWidthToShowMore": "Aumentar a largura do widget para permitir mais visualizações.",
-      "label": "Visualizar",
-      "views": {
-        "day": "Dia",
-        "list": "Lista",
-        "month": "Mês",
-        "week": "Semana",
-        "workWeek": "Semana útil"
-      }
-    },
-    "meetingsPanel": {
-      "actionsTitle": "Ações",
-      "filtersTitle": "Filtros",
-      "messageToAllBreakoutRoom": {
-        "placeholder": "Enviar uma mensagem...",
-        "sendFailed": "Por favor, tente de novo.",
-        "sendFailedTitle": "Falha ao enviar a mensagem",
-        "sendLabel": "Enviar mensagem para todas as salas",
-        "sendTimeout": "A alteração foi submetida com sucesso e será aplicada em breve.",
-        "sendTimeoutTitle": "O pedido foi enviado",
-        "title": "Enviar mensagem para todas as salas de sessões de breakout"
-      },
-      "scheduleBreakoutSession": "Agendar sessão de Breakout",
-      "scheduleMeeting": "Agendar reunião",
-      "tabTitle": "Visualizações",
-      "tabTitleInvitations": "Convites",
-      "tabTitleMeetings": "Reuniões"
-    },
-    "meetingsToolbar": {
-      "filterAriaLabel": "Procurar",
-      "filterPlaceholder": "Procurar...",
-      "next": {
-        "day": "Dia seguinte",
-        "month": "Mês seguinte",
-        "period": "Período seguinte",
-        "week": "Semana seguinte",
-        "workweek": "Próxima semana útil"
-      },
-      "previous": {
-        "day": "Dia anterior",
-        "month": "Mês anterior",
-        "period": "Período anterior",
-        "week": "Semana anterior",
-        "workweek": "Semana útil anterior"
-      },
-      "today": "Hoje"
-    },
-    "meetingViewEditMeeting": {
-      "breakoutSessionIsOver": "A sessão de breakout já terminou e não pode ser alterada.",
-      "meetingIsOver": "A reunião já terminou e não pode ser alterada."
-    },
-    "memberSelectionDropdown": {
-      "instructions_one": "{{selectedCount}} de {{count}} entrada selecionado. Utilize as teclas de setas para a esquerda e para a direita para navegar entre eles. Utilize as teclas de setas para cima e para baixo para aceder às opções disponíveis.",
-      "instructions_other": "{{selectedCount}} de {{count}} entrada selecionado. Utilize as teclas de setas para a esquerda e para a direita para navegar entre eles. Utilize as teclas de setas para cima e para baixo para aceder às opções disponíveis.",
-      "loadingError": "Erro ao carregar os utilizadores disponíveis.",
-      "loadingUsers": "Carregando utilizadores...",
-      "noMembers": "Sem membros disponíveis.",
-      "tagInstructions": "Utilize a tecla backspace para apagar a entrada."
-    },
-    "openMeetingRoomButton": {
-      "openMeetingRoom": "Abrir a sala de reunião",
-      "openMeetingRoom_breakout": "Abrir a sala de sessões de breakout"
-    },
-    "recurrenceEditor": {
-      "custom": {
-        "frequency": {
-          "days": "Dias",
-          "months": "Meses",
-          "weeks": "Semanas",
-          "years": "Anos"
-        },
-        "frequencyLabel": "Repetir",
-        "intervalLabel": "{{frequencyLabel}} até que a reunião seja repetida",
-        "invalidInput": "Entrada inválida",
-        "monthly": {
-          "byMonthday": "No dia",
-          "byMonthdayLong": "A reunião será repetida mensalmente em {{nthMonthday}}",
-          "byWeekday": "Em",
-          "byWeekdayLong": "A reunião será repetida mensalmente em {{ordinalLabel}} {{weekday}}",
-          "customRuleMode": "Regra personalizada",
-          "invalidInput": "Entrada inválida",
-          "monthdayInput": "Dia"
-        },
-        "repeatEvery": "Repetir a cada",
-        "title": "Reunião recorrente personalizada",
-        "weekly": {
-          "repeatOnWeekday": "No dia"
-        },
-        "yearly": {
-          "byMonthday": "On day",
-          "byMonthdayLong": "A reunião será repetida anualmente em {{nthMonthday}} {{month}}",
-          "byWeekday": "No",
-          "byWeekdayLong": "A reunião será repetida anualmente em {{ordinalLabel}} {{weekday}} de {{month}}",
-          "byWeekdayOf": "de",
-          "customRuleMode": "Regra personalizada",
-          "invalidInput": "Entrada inválida",
-          "monthdayInput": "Dia"
-        }
-      },
-      "monthLabel": "Mês",
-      "ordinalLabel": "Ordinal",
-      "ordinals": {
-        "first": "primeiro",
-        "fourth": "quarto",
-        "last": "último",
-        "second": "segundo",
-        "third": "terceiro"
-      },
-      "recurrencePreset": {
-        "custom": "Personalizada",
-        "daily": "Diariamente",
-        "mondayToFriday": "De segunda a sexta-feira",
-        "monthly": "Mensalmente",
-        "once": "Sem repetição",
-        "weekly": "Semanalmente",
-        "yearly": "Anualmente"
-      },
-      "recurringMeetingEnd": {
-        "afterMeetingCount": "Após",
-        "afterMeetingCountInput": "Contagem de reuniões",
-        "afterMeetingCountInputUnit": "Reuniões",
-        "afterMeetingCountLong_one": "Termina após {{count}} reuniões",
-        "afterMeetingCountLong_other": "Termina após {{count}} reuniões",
-        "endOfRecurringMeeting": "Fim da reunião recorrente",
-        "invalidInput": "Entrada inválida",
-        "never": "Nunca",
-        "neverLong": "A reunião será repetida para sempre",
-        "untilDate": "Em",
-        "untilDateInput": "Data em que a reunião recorrente termina",
-        "untilDateInputInvalid": "Data inválida",
-        "untilDateInputOpenDatePicker": "Selecione a data em que a reunião recorrente termina, a data selecionada {{date, datetime}}",
-        "untilDateLong": "A reunião será repetida até {{date,datetime}}"
-      },
-      "repeatMeeting": "Repetir reunião",
-      "ruleText": {
-        "afterMeetingCount_one": "uma vez",
-        "afterMeetingCount_other": "por {{count}} vezes",
-        "daily_one": "Todos day$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "daily_other": "Todos {{count}} days$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_bymonthday_one": "Todos os $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_bymonthday_other": "A cada {{count}} meses, em $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_byweekday_one": "Mensalmente, em {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_byweekday_other": "A cada  {{count}} meses, em {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_simple_one": "Todos os month$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "monthly_simple_other": "A cada {{count}} months$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "ordinal_ordinal_one": "{{count}}º",
-        "ordinal_ordinal_two": "{{count}}º",
-        "ordinal_ordinal_few": "{{count}}º",
-        "ordinal_ordinal_other": "{{count}}º",
-        "recurrenceEnd_count": " $t(recurrenceEditor.ruleText.afterMeetingCount, {\"count\": {{afterMeetingCount}}, \"ordinal\": false })",
-        "recurrenceEnd_never": "",
-        "recurrenceEnd_until": " até {{ untilDate, datetime(year: 'numeric'; month: 'long'; day: 'numeric') }}",
-        "unknown": "Recorrência não suportada",
-        "weekly_all_one": "Todos os week$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "weekly_all_other": "Todos os {{count}} weeks$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "weekly_some_one": "Semanalmente, em {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "weekly_some_other": "A cada {{count}} semanas, em {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "weekly_weekdays_one": "Todos os weekday$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "weekly_weekdays_other": "A cada {{count}} semanas, em weekdays$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_bymonthday_one": "Todos os {{monthLabel}} em $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_bymonthday_other": "Todos os {{count}} anos, em $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true }) of {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_byweekday_one": "Todos os {{monthLabel}} em {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_byweekday_other": "A cada {{count}} anos, em {{ordinalLabel}} {{byweekday}} of {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_simple_one": "Todos os year$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
-        "yearly_simple_other": "Todos os {{count}} years$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })"
-      },
-      "weekdayLabel": "Semanalmente"
-    },
-    "scheduleMeeting": {
-      "allowMessaging": "Permitir enviar mensagens a todos os participantes",
-      "cannotRemoveOwnUser": "Não pode remover o seu utilizador da reunião.",
-      "description": "Descrição",
-      "endAt": "Termina em",
-      "hasPowerToKickUser": "Não tem permissão para remover este participante.",
-      "meetingAlreadyStarted": "A reunião já iniciou.",
-      "participants": "Participantes",
-      "startAt": "Inicia em",
-      "title": "Título (necessário)",
-      "titleHelperText": "É necessário um título",
-      "typeToSearch": "Digite para procurar um utilizador...",
-      "youAreAlwaysMember": "O organizador vai sempre aceder à reunião."
-    },
-    "scheduleMeetingModal": {
-      "cancel": "Cancelar",
-      "create": "Criar reunião",
-      "scheduleTitle": "Agendar reunião"
-    },
-    "setupBreakoutSessions": {
-      "description": "Descrição",
-      "distributeAllRoomMembers": "Distribuir todos os {{amount}} participantes",
-      "endAt": "Termina em",
-      "groupNumber": "Número de grupos (necessário)",
-      "groupNumberErrorMessage": "Não existem participantes suficientes para o número de grupos que você inscreveu.",
-      "groups": "Grupos",
-      "groupTitleDefaultValue": "Grupo {{index}}",
-      "meetingIsOver": "A reunião já terminou e não pode criar sessões de breakout.",
-      "notAssignedMessage": "Alguns participantes não estão atribuídos a um grupo.",
-      "notAssignedTitle": "Observação",
-      "startAt": "Inicia em"
-    },
-    "setupBreakoutSessionsModal": {
-      "cancel": "Cancelar",
-      "create": "Criar uma sessão de Breakout",
-      "title": "Agendar uma sessão de Breakout"
-    },
-    "timeDistance": {
-      "futureText": "{{duration, relativetime}}",
-      "futureTextExact": "em {{duration}}",
-      "remainingText": "Termina {{duration, relativetime}}",
-      "remainingTextExact": "Termina em {{duration}}"
-    },
-    "widgetSelectionDropdown": {
-      "allActive": "Todos os widgets disponíveis estão ativos.",
-      "instructions_one": "{{selectedCount}} de {{count}} entrada selecionados. Utilize as teclas de setas para a esquerda e para a direita para navegar entre elas. Utilize as teclas de setas para cima e para baixo para selecionar as opções.",
-      "instructions_other": "{{selectedCount}} de {{count}} entrada selecionados. Utilize as teclas de setas para a esquerda e para a direita para navegar entre elas. Utilize as teclas de setas para cima e para baixo para selecionar as opções.",
-      "label": "Widgets",
-      "loading": "A carregar widgets...",
-      "loadingError": "Erro ao carregar Widgets disponíveis.",
-      "noWidgets": "Sem Widgets disponíveis.",
-      "tagInstructions": "Utilize a tecla backspace para apagar a entrada."
+    "header": {
+      "deleteConfirmButton": "Apagar",
+      "deleteConfirmHeader": "Apagar reunião",
+      "deleteConfirmMessage": "Tem a certeza que pretende apagar a reunião “{{title}}” em {{startTime, datetime}} e todo o conteúdo relacionado com a mesma?",
+      "deleteFailed": "Por favor, tente de novo.",
+      "deleteFailedTitle": "Falha ao apagar a reunião",
+      "deleteInOpenXchangeMenu": "Apagar a reunião em Open-Xchange",
+      "deleteMeetingConfirmButton": "Apagar reunião",
+      "deleteMenu": "Apagar",
+      "deleteSeriesConfirmButton": "Apagar série",
+      "deleteSeriesConfirmMessage": "Tem a certeza que pretende apagara a reunião ou a série de reuniões “{{title}}” em {{startTime, datetime}} e todo o conteúdo relacionado com a mesma?",
+      "editInOpenXchangeMenu": "Editar reunião em Open-Xchange",
+      "editMenu": "Editar",
+      "join": "Aceder",
+      "joinBreakout_breakout": "Aceder"
     }
+  },
+  "meetingHasBreakoutSessionsWarning": {
+    "message": "Se pretender alterar a hora de início ou fim desta reunião, as sessões de breakout não serão movidas!",
+    "title": "A reunião já tem sessões de breakout."
+  },
+  "meetingInvitationGuard": {
+    "meetingInvitation": "Por favor, aceite o convite para a reunião para ver todos os detalhes."
+  },
+  "meetingList": {
+    "groupTitle": "{{date, datetime}}",
+    "noBreakoutSessionsScheduled": "Não existem sessões de breakout agendadas que correspondam aos filtros selecionados.",
+    "noMeetingsScheduled": "Não existem reuniões agendadas que correspondam aos filtros selecionados.",
+    "openInvitationsDetail": "Por favor, aceda a todas as salas de reunião.",
+    "openInvitationsTitle": "Tem convites abertos.",
+    "title": "Reuniões"
+  },
+  "meetingsCalendar": {
+    "event": {
+      "startTime": "{{startTime, datetime}}",
+      "summary_default": "{{startTime, datetime}}–{{endTime, datetime}}: “{{title}}” por {{creator}}",
+      "summary_recurring": "{{startTime, datetime}}–{{endTime, datetime}}: “{{title}}” por {{creator}}, reunião recorrente"
+    }
+  },
+  "meetingsFilter": {
+    "filterAriaLabel": "Procurar",
+    "filterPlaceholder": "Procurar..."
+  },
+  "meetingsNavigation": {
+    "increaseWidth": "Aumentar a largura do widget",
+    "increaseWidthToShowMore": "Aumentar a largura do widget para permitir mais visualizações.",
+    "label": "Visualizar",
+    "views": {
+      "day": "Dia",
+      "list": "Lista",
+      "month": "Mês",
+      "week": "Semana",
+      "workWeek": "Semana útil"
+    }
+  },
+  "meetingsPanel": {
+    "actionsTitle": "Ações",
+    "filtersTitle": "Filtros",
+    "messageToAllBreakoutRoom": {
+      "placeholder": "Enviar uma mensagem...",
+      "sendFailed": "Por favor, tente de novo.",
+      "sendFailedTitle": "Falha ao enviar a mensagem",
+      "sendLabel": "Enviar mensagem para todas as salas",
+      "sendTimeout": "A alteração foi submetida com sucesso e será aplicada em breve.",
+      "sendTimeoutTitle": "O pedido foi enviado",
+      "title": "Enviar mensagem para todas as salas de sessões de breakout"
+    },
+    "scheduleBreakoutSession": "Agendar sessão de Breakout",
+    "scheduleMeeting": "Agendar reunião",
+    "tabTitle": "Visualizações",
+    "tabTitleInvitations": "Convites",
+    "tabTitleMeetings": "Reuniões"
+  },
+  "meetingsToolbar": {
+    "filterAriaLabel": "Procurar",
+    "filterPlaceholder": "Procurar...",
+    "next": {
+      "day": "Dia seguinte",
+      "month": "Mês seguinte",
+      "period": "Período seguinte",
+      "week": "Semana seguinte",
+      "workweek": "Próxima semana útil"
+    },
+    "previous": {
+      "day": "Dia anterior",
+      "month": "Mês anterior",
+      "period": "Período anterior",
+      "week": "Semana anterior",
+      "workweek": "Semana útil anterior"
+    },
+    "today": "Hoje"
+  },
+  "meetingViewEditMeeting": {
+    "breakoutSessionIsOver": "A sessão de breakout já terminou e não pode ser alterada.",
+    "meetingIsOver": "A reunião já terminou e não pode ser alterada."
+  },
+  "memberSelectionDropdown": {
+    "instructions_one": "{{selectedCount}} de {{count}} entrada selecionado. Utilize as teclas de setas para a esquerda e para a direita para navegar entre eles. Utilize as teclas de setas para cima e para baixo para aceder às opções disponíveis.",
+    "instructions_other": "{{selectedCount}} de {{count}} entrada selecionado. Utilize as teclas de setas para a esquerda e para a direita para navegar entre eles. Utilize as teclas de setas para cima e para baixo para aceder às opções disponíveis.",
+    "loadingError": "Erro ao carregar os utilizadores disponíveis.",
+    "loadingUsers": "Carregando utilizadores...",
+    "noMembers": "Sem membros disponíveis.",
+    "tagInstructions": "Utilize a tecla backspace para apagar a entrada."
+  },
+  "openMeetingRoomButton": {
+    "openMeetingRoom": "Abrir a sala de reunião",
+    "openMeetingRoom_breakout": "Abrir a sala de sessões de breakout"
+  },
+  "recurrenceEditor": {
+    "custom": {
+      "frequency": {
+        "days": "Dias",
+        "months": "Meses",
+        "weeks": "Semanas",
+        "years": "Anos"
+      },
+      "frequencyLabel": "Repetir",
+      "intervalLabel": "{{frequencyLabel}} até que a reunião seja repetida",
+      "invalidInput": "Entrada inválida",
+      "monthly": {
+        "byMonthday": "No dia",
+        "byMonthdayLong": "A reunião será repetida mensalmente em {{nthMonthday}}",
+        "byWeekday": "Em",
+        "byWeekdayLong": "A reunião será repetida mensalmente em {{ordinalLabel}} {{weekday}}",
+        "customRuleMode": "Regra personalizada",
+        "invalidInput": "Entrada inválida",
+        "monthdayInput": "Dia"
+      },
+      "repeatEvery": "Repetir a cada",
+      "title": "Reunião recorrente personalizada",
+      "weekly": {
+        "repeatOnWeekday": "No dia"
+      },
+      "yearly": {
+        "byMonthday": "On day",
+        "byMonthdayLong": "A reunião será repetida anualmente em {{nthMonthday}} {{month}}",
+        "byWeekday": "No",
+        "byWeekdayLong": "A reunião será repetida anualmente em {{ordinalLabel}} {{weekday}} de {{month}}",
+        "byWeekdayOf": "de",
+        "customRuleMode": "Regra personalizada",
+        "invalidInput": "Entrada inválida",
+        "monthdayInput": "Dia"
+      }
+    },
+    "monthLabel": "Mês",
+    "ordinalLabel": "Ordinal",
+    "ordinals": {
+      "first": "primeiro",
+      "fourth": "quarto",
+      "last": "último",
+      "second": "segundo",
+      "third": "terceiro"
+    },
+    "recurrencePreset": {
+      "custom": "Personalizada",
+      "daily": "Diariamente",
+      "mondayToFriday": "De segunda a sexta-feira",
+      "monthly": "Mensalmente",
+      "once": "Sem repetição",
+      "weekly": "Semanalmente",
+      "yearly": "Anualmente"
+    },
+    "recurringMeetingEnd": {
+      "afterMeetingCount": "Após",
+      "afterMeetingCountInput": "Contagem de reuniões",
+      "afterMeetingCountInputUnit": "Reuniões",
+      "afterMeetingCountLong_one": "Termina após {{count}} reuniões",
+      "afterMeetingCountLong_other": "Termina após {{count}} reuniões",
+      "endOfRecurringMeeting": "Fim da reunião recorrente",
+      "invalidInput": "Entrada inválida",
+      "never": "Nunca",
+      "neverLong": "A reunião será repetida para sempre",
+      "untilDate": "Em",
+      "untilDateInput": "Data em que a reunião recorrente termina",
+      "untilDateInputInvalid": "Data inválida",
+      "untilDateInputOpenDatePicker": "Selecione a data em que a reunião recorrente termina, a data selecionada {{date, datetime}}",
+      "untilDateLong": "A reunião será repetida até {{date,datetime}}"
+    },
+    "repeatMeeting": "Repetir reunião",
+    "ruleText": {
+      "afterMeetingCount_one": "uma vez",
+      "afterMeetingCount_other": "por {{count}} vezes",
+      "daily_one": "Todos day$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "daily_other": "Todos {{count}} days$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_bymonthday_one": "Todos os $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_bymonthday_other": "A cada {{count}} meses, em $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_byweekday_one": "Mensalmente, em {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_byweekday_other": "A cada  {{count}} meses, em {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_simple_one": "Todos os month$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "monthly_simple_other": "A cada {{count}} months$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "ordinal_ordinal_one": "{{count}}º",
+      "ordinal_ordinal_two": "{{count}}º",
+      "ordinal_ordinal_few": "{{count}}º",
+      "ordinal_ordinal_other": "{{count}}º",
+      "recurrenceEnd_count": " $t(recurrenceEditor.ruleText.afterMeetingCount, {\"count\": {{afterMeetingCount}}, \"ordinal\": false })",
+      "recurrenceEnd_never": "",
+      "recurrenceEnd_until": " até {{ untilDate, datetime(year: 'numeric'; month: 'long'; day: 'numeric') }}",
+      "unknown": "Recorrência não suportada",
+      "weekly_all_one": "Todos os week$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_all_other": "Todos os {{count}} weeks$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_some_one": "Semanalmente, em {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_some_other": "A cada {{count}} semanas, em {{weekdays, list}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_weekdays_one": "Todos os weekday$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "weekly_weekdays_other": "A cada {{count}} semanas, em weekdays$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_bymonthday_one": "Todos os {{monthLabel}} em $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true })$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_bymonthday_other": "Todos os {{count}} anos, em $t(recurrenceEditor.ruleText.ordinal, {\"count\": {{bymonthday}}, \"ordinal\": true }) of {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_byweekday_one": "Todos os {{monthLabel}} em {{ordinalLabel}} {{byweekday}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_byweekday_other": "A cada {{count}} anos, em {{ordinalLabel}} {{byweekday}} of {{monthLabel}}$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_simple_one": "Todos os year$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })",
+      "yearly_simple_other": "Todos os {{count}} years$t(recurrenceEditor.ruleText.recurrenceEnd, {\"context\": \"{{recurrenceEnd}}\" })"
+    },
+    "weekdayLabel": "Semanalmente"
+  },
+  "scheduleMeeting": {
+    "allowMessaging": "Permitir enviar mensagens a todos os participantes",
+    "cannotRemoveOwnUser": "Não pode remover o seu utilizador da reunião.",
+    "description": "Descrição",
+    "endAt": "Termina em",
+    "hasPowerToKickUser": "Não tem permissão para remover este participante.",
+    "meetingAlreadyStarted": "A reunião já iniciou.",
+    "participants": "Participantes",
+    "startAt": "Inicia em",
+    "title": "Título (necessário)",
+    "titleHelperText": "É necessário um título",
+    "typeToSearch": "Digite para procurar um utilizador...",
+    "youAreAlwaysMember": "O organizador vai sempre aceder à reunião."
+  },
+  "scheduleMeetingModal": {
+    "cancel": "Cancelar",
+    "create": "Criar reunião",
+    "scheduleTitle": "Agendar reunião"
+  },
+  "setupBreakoutSessions": {
+    "description": "Descrição",
+    "distributeAllRoomMembers": "Distribuir todos os {{amount}} participantes",
+    "endAt": "Termina em",
+    "groupNumber": "Número de grupos (necessário)",
+    "groupNumberErrorMessage": "Não existem participantes suficientes para o número de grupos que você inscreveu.",
+    "groups": "Grupos",
+    "groupTitleDefaultValue": "Grupo {{index}}",
+    "meetingIsOver": "A reunião já terminou e não pode criar sessões de breakout.",
+    "notAssignedMessage": "Alguns participantes não estão atribuídos a um grupo.",
+    "notAssignedTitle": "Observação",
+    "startAt": "Inicia em"
+  },
+  "setupBreakoutSessionsModal": {
+    "cancel": "Cancelar",
+    "create": "Criar uma sessão de Breakout",
+    "title": "Agendar uma sessão de Breakout"
+  },
+  "timeDistance": {
+    "futureText": "{{duration, relativetime}}",
+    "futureTextExact": "em {{duration}}",
+    "remainingText": "Termina {{duration, relativetime}}",
+    "remainingTextExact": "Termina em {{duration}}"
+  },
+  "widgetSelectionDropdown": {
+    "allActive": "Todos os widgets disponíveis estão ativos.",
+    "instructions_one": "{{selectedCount}} de {{count}} entrada selecionados. Utilize as teclas de setas para a esquerda e para a direita para navegar entre elas. Utilize as teclas de setas para cima e para baixo para selecionar as opções.",
+    "instructions_other": "{{selectedCount}} de {{count}} entrada selecionados. Utilize as teclas de setas para a esquerda e para a direita para navegar entre elas. Utilize as teclas de setas para cima e para baixo para selecionar as opções.",
+    "label": "Widgets",
+    "loading": "A carregar widgets...",
+    "loadingError": "Erro ao carregar Widgets disponíveis.",
+    "noWidgets": "Sem Widgets disponíveis.",
+    "tagInstructions": "Utilize a tecla backspace para apagar a entrada."
   }
-  
+}

--- a/matrix-meetings-widget/src/components/common/LocalizationProvider.tsx
+++ b/matrix-meetings-widget/src/components/common/LocalizationProvider.tsx
@@ -16,7 +16,10 @@
 
 import {
   deDE,
+  esES,
+  frFR,
   enUS,
+  ptBR,
   LocalizationProvider as MuiLocalizationProvider,
 } from '@mui/x-date-pickers';
 import { PropsWithChildren } from 'react';
@@ -26,8 +29,18 @@ import { AdapterLuxonWeekday } from './AdapterLuxonWeekday';
 export function LocalizationProvider({ children }: PropsWithChildren<{}>) {
   const { i18n } = useTranslation();
   const language: string | undefined = i18n.languages?.[0];
-  const locale =
-    language && new Intl.Locale(language).language === 'de' ? deDE : enUS;
+  let locale;
+  if (language && new Intl.Locale(language).language === 'de') {
+    locale = deDE;
+  } else if (language && new Intl.Locale(language).language === 'es') {
+    locale = esES;
+  } else if (language && new Intl.Locale(language).language === 'fr') {
+    locale = frFR;
+  } else if (language && new Intl.Locale(language).language === 'pt') {
+    locale = ptBR;
+  } else {
+    locale = enUS;
+  }
 
   return (
     <MuiLocalizationProvider

--- a/matrix-meetings-widget/src/components/common/LocalizationProvider.tsx
+++ b/matrix-meetings-widget/src/components/common/LocalizationProvider.tsx
@@ -16,11 +16,11 @@
 
 import {
   deDE,
+  enUS,
   esES,
   frFR,
-  enUS,
-  ptBR,
   LocalizationProvider as MuiLocalizationProvider,
+  ptBR,
 } from '@mui/x-date-pickers';
 import { PropsWithChildren } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/matrix-meetings-widget/src/components/meetings/MeetingsCalendar/MeetingsCalendar.tsx
+++ b/matrix-meetings-widget/src/components/meetings/MeetingsCalendar/MeetingsCalendar.tsx
@@ -87,12 +87,12 @@ export const MeetingsCalendar = ({
     language && new Intl.Locale(language).language === 'de'
       ? deLocale
       : language && new Intl.Locale(language).language === 'es'
-      ? esLocale
-      : language && new Intl.Locale(language).language === 'fr'
-      ? frLocale
-      : language && new Intl.Locale(language).language === 'pt'
-      ? ptLocale
-      : undefined;
+        ? esLocale
+        : language && new Intl.Locale(language).language === 'fr'
+          ? frLocale
+          : language && new Intl.Locale(language).language === 'pt'
+            ? ptLocale
+            : undefined;
   const [detailsMeetingId, setDetailsMeetingId] = useState<
     | { meetingId: string; uid: string; recurrenceId: string | undefined }
     | undefined

--- a/matrix-meetings-widget/src/components/meetings/MeetingsCalendar/MeetingsCalendar.tsx
+++ b/matrix-meetings-widget/src/components/meetings/MeetingsCalendar/MeetingsCalendar.tsx
@@ -24,6 +24,9 @@ import {
   MoreLinkSimpleAction,
 } from '@fullcalendar/core';
 import deLocale from '@fullcalendar/core/locales/de';
+import esLocale from '@fullcalendar/core/locales/es';
+import frLocale from '@fullcalendar/core/locales/fr';
+import ptLocale from '@fullcalendar/core/locales/pt';
 import FullCalendar from '@fullcalendar/react';
 import { useWidgetApi } from '@matrix-widget-toolkit/react';
 import { unstable_useId as useId } from '@mui/utils';
@@ -83,6 +86,12 @@ export const MeetingsCalendar = ({
   const locale =
     language && new Intl.Locale(language).language === 'de'
       ? deLocale
+      : language && new Intl.Locale(language).language === 'es'
+      ? esLocale
+      : language && new Intl.Locale(language).language === 'fr'
+      ? frLocale
+      : language && new Intl.Locale(language).language === 'pt'
+      ? ptLocale
       : undefined;
   const [detailsMeetingId, setDetailsMeetingId] = useState<
     | { meetingId: string; uid: string; recurrenceId: string | undefined }

--- a/matrix-meetings-widget/src/i18n.ts
+++ b/matrix-meetings-widget/src/i18n.ts
@@ -55,7 +55,7 @@ i18n
       backends: [HttpBackend, WidgetToolkitI18nBackend],
     },
 
-    supportedLngs: ['en', 'de'],
+    supportedLngs: ['pt', 'en', 'fr', 'es', 'de'],
     nonExplicitSupportedLngs: true,
   });
 

--- a/matrix-meetings-widget/src/setupTests.ts
+++ b/matrix-meetings-widget/src/setupTests.ts
@@ -31,8 +31,17 @@ import { mockDateTimeFormatTimeZone } from './testing';
 // Use a different configuration for i18next during tests
 vi.mock('./i18n', async () => {
   const i18n = await vi.importActual<typeof import('i18next')>('i18next');
+  const pt = {
+    translation: await vi.importActual('../public/locales/pt/translation.json'),
+  };
   const en = {
     translation: await vi.importActual('../public/locales/en/translation.json'),
+  };
+  const fr = {
+    translation: await vi.importActual('../public/locales/fr/translation.json'),
+  };
+  const es = {
+    translation: await vi.importActual('../public/locales/es/translation.json'),
   };
   const de = {
     translation: await vi.importActual('../public/locales/de/translation.json'),
@@ -49,7 +58,10 @@ vi.mock('./i18n', async () => {
       escapeValue: false,
     },
     resources: {
+      pt,
       en,
+      fr,
+      es,
       de,
     },
   });


### PR DESCRIPTION
This PR introduces new translations for the **Meetings Bot** and **Meetings Widget** in **Portuguese (pt)**, **French (fr)**, and **Spanish (es)**. Additionally, it includes fixes for the existing translations in **English (en)** and **German (de)** to ensure consistency and accuracy across all supported languages.